### PR TITLE
FUND-1661 ZRC Out-of-memory on GET case when calculating Etag

### DIFF
--- a/src/Roxit.ZGW.Common.Web/Filters/ETagFilter.cs
+++ b/src/Roxit.ZGW.Common.Web/Filters/ETagFilter.cs
@@ -86,7 +86,7 @@ internal static class ETagService
             using var jsonWriter = new JsonTextWriter(writer);
 
             // Note: Set ReferenceLoopHandling to Ignore: Serializing Geometrie throws an exception when this is not set:
-            //         Newtonsoft.Json.JsonSerializationException: Self referencing loop detected for property 'CoordinateValue' with type 
+            //         Newtonsoft.Json.JsonSerializationException: Self referencing loop detected for property 'CoordinateValue' with type
             var serializer = new JsonSerializer() { ReferenceLoopHandling = ReferenceLoopHandling.Ignore };
             serializer.Serialize(jsonWriter, value);
         }


### PR DESCRIPTION
# Pull Request

## Description

<!-- Brief description of the changes -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Related Issues

<!-- Link to issues: Fixes #123 -->

## Testing

- [ ] Tests pass
- [ ] Manual testing completed

## Checklist

- [ ] Self-review completed
- [ ] Documentation updated (if needed)
