### PR TITLE
FUND-1625 - Set domain in cert generation script

### DIFF
--- a/tools/oneground-certificates-generator/Dockerfile
+++ b/tools/oneground-certificates-generator/Dockerfile
@@ -4,10 +4,12 @@ RUN apk add --no-cache openssl
 
 WORKDIR /app
 
+ENV DOMAIN=oneground.local
+
 COPY generate-oneground-certificates.sh .
 
 RUN sed -i 's/\r$//' generate-oneground-certificates.sh
 
 RUN chmod +x generate-oneground-certificates.sh
 
-CMD ["./generate-oneground-certificates.sh"]
+CMD "./generate-oneground-certificates.sh" $DOMAIN

--- a/tools/oneground-certificates-generator/generate-oneground-certificates.sh
+++ b/tools/oneground-certificates-generator/generate-oneground-certificates.sh
@@ -3,7 +3,7 @@
 set -e
 
 CERT_DIR="/certs"
-DOMAIN="oneground.local"
+DOMAIN="${1:-oneground.local}"
 
 CERT_FILE_PEM="${CERT_DIR}/${DOMAIN}.pem"
 CERT_FILE_CRT="${CERT_DIR}/${DOMAIN}.crt"


### PR DESCRIPTION
# Pull Request

## Description

Added possibility to set domain value for oneground certificate(default value - oneground.local)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## Related Issues

FUND-1625

## Testing

- [x] Tests pass
- [x] Manual testing completed

## Checklist

- [x] Self-review completed
- [x] Documentation updated (if needed)
