### PR TITLE
Add support for self issued jwt tokens

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -1,0 +1,88 @@
+# Authentication for OneGround ZGW APIs
+
+This guide explains how to authenticate against the ZGW APIs during local development and demos.
+
+## Supported token types
+
+- **OAuth2 access tokens (recommended)**
+  - Issued via standard flows (e.g. client credentials as in this guide).
+  - Tokens are verified by checking the signature with the Identity Provider's public keys (JWKS), enabling offline validation and reducing network calls.
+  - Tokens are issued in one place (the Identity Provider), so you can centrally enforce short expiration times, rotate keys, and revoke compromised clients.
+  - Any standards‑compliant OAuth2 Identity Provider can be used to issue access tokens for these APIs. Keycloak is used in this repository only as an example.
+  - Each access token must include an `rsin` claim that contains the organization's RSIN. APIs use this claim for tenant/organization context. In this local Keycloak setup, `rsin` claim is added via hardcoded claim mapper on the api client. When using a different Identity Provider, configure an equivalent claim/attribute mapping so that issued access tokens contain the `rsin` claim.
+
+- **ZGW standard tokens (legacy/backwards compatibility)**
+  - Self‑issued JWTs signed with HS256 (HMAC‑SHA256) using the Keycloak client's secret.
+  - Must include a `client_id` claim that matches a client in the Keycloak realm.
+  - Supported only with Keycloak together with the custom token introspection plugin. See the project for details: [Keycloak-ZGW-Token-Introspection](https://github.com/OneGround/Keycloak-ZGW-Token-Introspection).
+  - Use short token lifetimes. Tokens without an `exp` claim are treated as active, but it's not recommended to use non expiring access tokens.
+
+## API Authentication using OAuth2 access tokens
+
+#### Get the Client Secret from Keycloak
+
+1. Navigate to the Keycloak admin console: [http://localhost:8080/admin/master/console/#/OneGround/](http://localhost:8080/admin/master/console/#/OneGround/)
+2. Log in using the credentials:
+   - **Username**: `admin`
+   - **Password**: `admin`
+3. From the navigation on the left, select **Clients**.
+4. Select the `oneground-000000000` client from the list.
+   > **Note on the Default Client:** This local setup is configured with a single default client, `oneground-000000000`, which has full administrative access to all APIs. If you wish to add more clients with specific permissions, you must first create them in Keycloak by following the [Keycloak Setup Guide](./localdev/keycloak/KeycloakSetup/README.md). After creating a new client, you must also configure its permissions using the Autorisaties API or by updating the [autorisaties service's seed data](./localdev/oneground-services-data/ac-data/applicaties.json).
+5. Go to the **Credentials** tab.
+6. Copy the value from the **Client Secret** field. This is your `<oneground-client-secret>`.
+
+#### Request an Access Token
+
+Now you can exchange the client credentials for a temporary access token. Use the command for your operating system, replacing `<oneground-client-secret>` with your actual secret. The default client ID is `oneground-000000000`.
+
+##### For Windows (PowerShell)
+
+- Open Windows PowerShell and execute this command:
+
+```powershell
+$response = Invoke-WebRequest `
+    -Uri "http://localhost:8080/realms/OneGround/protocol/openid-connect/token" `
+    -Method POST `
+    -Headers @{"Content-Type" = "application/x-www-form-urlencoded"} `
+    -Body "grant_type=client_credentials&client_id=oneground-000000000&client_secret=<oneground-client-secret>"
+```
+
+- Then take an access token from `$response`:
+
+```powershell
+$response.Content
+```
+
+##### For Linux, macOS, or WSL (cURL)
+
+- Open terminal and execute this command:
+
+```bash
+curl --location --request POST 'http://localhost:8080/realms/OneGround/protocol/openid-connect/token' \
+--header 'Content-Type: application/x-www-form-urlencoded' \
+--data-urlencode 'grant_type=client_credentials' \
+--data-urlencode 'client_id=oneground-000000000' \
+--data-urlencode 'client_secret=<oneground-client-secret>'
+```
+
+You will receive a JSON response containing the `access_token`. You can now use this token as a `Bearer` token to authorize your API requests.
+
+```json
+{
+    "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAi......",
+    "expires_in": 300,
+    "refresh_expires_in": 0,
+    "token_type": "Bearer"
+}
+```
+
+> **Tip: How to Increase Token Expiration Time (For Testing Only)**
+>
+> **Warning:** Extending access token lifespans reduces security. Long-lived tokens are easier to steal and misuse and increase the impact of any leak because they remain valid for longer. Only increase token lifespans for local testing in non-production environments.
+> By default, the access token expires in 5 minutes (300 seconds). To increase this time:
+>
+> 1. Navigate directly to the **Tokens** settings page in Keycloak: [http://localhost:8080/admin/master/console/#/OneGround/realm-settings/tokens](http://localhost:8080/admin/master/console/#/OneGround/realm-settings/tokens).
+> 2. In the `Access Token Lifespan` field, set a longer duration (e.g., `30 minutes` or `1 hour`).
+> 3. Click **Save**.
+>
+> You will need to request a new token for this change to take effect.

--- a/getting-started/docker-compose/README.md
+++ b/getting-started/docker-compose/README.md
@@ -14,12 +14,10 @@
       - [Step 5.1: Get the Client Secret from Keycloak](#step-51-get-the-client-secret-from-keycloak)
       - [Step 5.2: Update Environment File and Restart Services](#step-52-update-environment-file-and-restart-services)
       - [Step 5.3: Request an Access Token](#step-53-request-an-access-token)
-        - [For Windows (PowerShell)](#for-windows-powershell)
-        - [For Linux, macOS, or WSL (cURL)](#for-linux-macos-or-wsl-curl)
       - [Step 5.4: Creating a Sample Case Using Postman](#step-54-creating-a-sample-case-using-postman)
     - [6. Stopping the Services](#6-stopping-the-services)
   - [Service Endpoints and Tools](#service-endpoints-and-tools)
-    - [ZGW API Services](#zgw-api-services)
+    - [ZGW API Services/Listeners](#zgw-api-serviceslisteners)
     - [Hosted Tools](#hosted-tools)
   - [License](#license)
 
@@ -160,15 +158,7 @@ To make authorized requests to the APIs, you first need to get a client secret f
 
 #### Step 5.1: Get the Client Secret from Keycloak
 
-1. Navigate to the Keycloak admin console: [http://localhost:8080/admin/master/console/#/OneGround/](http://localhost:8080/admin/master/console/#/OneGround/)
-2. Log in using the credentials:
-   - **Username**: `admin`
-   - **Password**: `admin`
-3. From the navigation on the left, select **Clients**.
-4. Select the `oneground-000000000` client from the list.
-   > **Note on the Default Client:** This local setup is configured with a single default client, `oneground-000000000`, which has full administrative access to all APIs. If you wish to add more clients with specific permissions, you must first create them in Keycloak by following the [Keycloak Setup Guide](../../localdev/keycloak/KeycloakSetup/README.md). After creating a new client, you must also configure its permissions using the Autorisaties API or by updating the [autorisaties service's seed data](../oneground-services-data/ac-data/applicaties.json).
-5. Go to the **Credentials** tab.
-6. Copy the value from the **Client Secret** field. This is your `<oneground-client-secret>`.
+See [AUTHENTICATION.md](../../AUTHENTICATION.md).
 
 #### Step 5.2: Update Environment File and Restart Services
 
@@ -194,57 +184,7 @@ To make authorized requests to the APIs, you first need to get a client secret f
 
 #### Step 5.3: Request an Access Token
 
-This process uses the standard OAuth 2.0 Client Credentials grant type to obtain an access token. Now you can exchange the client credentials for a temporary access token. Use the command for your operating system, replacing `<oneground-client-secret>` with your actual secret. The default client ID is `oneground-000000000`.
-
-##### For Windows (PowerShell)
-
-- Open Windows PowerShell and execute this command:
-
-    ```powershell
-    $response = Invoke-WebRequest `
-        -Uri "http://localhost:8080/realms/OneGround/protocol/openid-connect/token" `
-        -Method POST `
-        -Headers @{"Content-Type" = "application/x-www-form-urlencoded"} `
-        -Body "grant_type=client_credentials&client_id=oneground-000000000&client_secret=<oneground-client-secret>"
-    ```
-
-- Then take an access token from `$response`:
-
-    ```powershell
-    $response.Content
-    ```
-
-##### For Linux, macOS, or WSL (cURL)
-
-- Open terminal and execute this command:
-
-    ```bash
-    curl --location --request POST 'http://localhost:8080/realms/OneGround/protocol/openid-connect/token' \
-    --header 'Content-Type: application/x-www-form-urlencoded' \
-    --data-urlencode 'grant_type=client_credentials' \
-    --data-urlencode 'client_id=oneground-000000000' \
-    --data-urlencode 'client_secret=<oneground-client-secret>'
-    ```
-
-You will receive a JSON response containing the `access_token`. You can now use this token as a `Bearer` token to authorize your API requests.
-
-```json
-{
-    "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAi......",
-    "expires_in": 300,
-    "refresh_expires_in": 0,
-    "token_type": "Bearer"
-}
-```
-
-> **Tip: How to Increase Token Expiration Time**
-> By default, the access token expires in 5 minutes (300 seconds). To increase this time:
->
-> 1. Navigate directly to the **Tokens** settings page in Keycloak: [http://localhost:8080/admin/master/console/#/OneGround/realm-settings/tokens](http://localhost:8080/admin/master/console/#/OneGround/realm-settings/tokens).
-> 2. In the `Access Token Lifespan` field, set a longer duration (e.g., `30 minutes` or `1 hour`).
-> 3. Click **Save**.
->
-> You will need to request a new token for this change to take effect.
+See [AUTHENTICATION.md](../../AUTHENTICATION.md).
 
 #### Step 5.4: Creating a Sample Case Using Postman
 

--- a/getting-started/docker-compose/docker-compose.yml
+++ b/getting-started/docker-compose/docker-compose.yml
@@ -83,6 +83,13 @@ services:
     networks:
       - oneground
 
+  keycloak-provider-downloader:
+    image: alpine:3.22
+    command: sh -c "if [ -f /providers/zgw-token-introspection.jar ]; then echo 'JAR present'; else wget -q -O /providers/zgw-token-introspection.jar https://github.com/OneGround/Keycloak-ZGW-Token-Introspection/releases/download/v1/zgw-token-introspection.jar && chmod 644 /providers/zgw-token-introspection.jar; fi"
+    volumes:
+      - kc-providers:/providers
+    restart: "no"
+
   keycloak:
     image: quay.io/keycloak/keycloak:26.3.1
     restart: unless-stopped
@@ -107,9 +114,13 @@ services:
       retries: 8
       start_period: 5s
     command: ["start-dev"]
+    volumes:
+      - kc-providers:/opt/keycloak/providers:ro
     depends_on:
       postgres_docker_db:
         condition: service_healthy
+      keycloak-provider-downloader:
+        condition: service_completed_successfully
     networks:
       - oneground
 
@@ -363,6 +374,7 @@ services:
 
 volumes:
   postgres:
+  kc-providers:
 
 networks:
   oneground:

--- a/localdev/README.md
+++ b/localdev/README.md
@@ -14,11 +14,9 @@
       - [Step 5.1: Get the Client Secret from Keycloak](#step-51-get-the-client-secret-from-keycloak)
       - [Step 5.2: Update Environment File and Restart Services](#step-52-update-environment-file-and-restart-services)
       - [Step 5.3: Request an Access Token](#step-53-request-an-access-token)
-        - [For Windows (PowerShell)](#for-windows-powershell)
-        - [For Linux, macOS, or WSL (cURL)](#for-linux-macos-or-wsl-curl)
     - [6. Stopping the Services](#6-stopping-the-services)
   - [Service Endpoints and Tools](#service-endpoints-and-tools)
-    - [ZGW API Services](#zgw-api-services)
+    - [ZGW API Services/listeners](#zgw-api-serviceslisteners)
     - [Hosted Tools](#hosted-tools)
 
 ## About This Guide
@@ -163,15 +161,7 @@ To make authorized requests to the APIs, you first need to get a client secret f
 
 #### Step 5.1: Get the Client Secret from Keycloak
 
-1. Navigate to the Keycloak admin console: [http://localhost:8080/admin/master/console/#/OneGround/](http://localhost:8080/admin/master/console/#/OneGround/)
-2. Log in using the credentials:
-   - **Username**: `admin`
-   - **Password**: `admin`
-3. From the navigation on the left, select **Clients**.
-4. Select the `oneground-000000000` client from the list.
-   > **Note on the Default Client:** This local setup is configured with a single default client, `oneground-000000000`, which has full administrative access to all APIs. If you wish to add more clients with specific permissions, you must first create them in Keycloak by following the [Keycloak Setup Guide](./keycloak/KeycloakSetup/README.md). After creating a new client, you must also configure its permissions using the Autorisaties API or by updating the [autorisaties service's seed data](./oneground-services-data/ac-data/applicaties.json).
-5. Go to the **Credentials** tab.
-6. Copy the value from the **Client Secret** field. This is your `<oneground-client-secret>`.
+See [AUTHENTICATION.md](../AUTHENTICATION.md).
 
 #### Step 5.2: Update Environment File and Restart Services
 
@@ -197,57 +187,7 @@ To make authorized requests to the APIs, you first need to get a client secret f
 
 #### Step 5.3: Request an Access Token
 
-Now you can exchange the client credentials for a temporary access token. Use the command for your operating system, replacing `<oneground-client-secret>` with your actual secret. The default client ID is `oneground-000000000`.
-
-##### For Windows (PowerShell)
-
-- Open Windows PowerShell and execute this command:
-
-    ```powershell
-    $response = Invoke-WebRequest `
-        -Uri "http://localhost:8080/realms/OneGround/protocol/openid-connect/token" `
-        -Method POST `
-        -Headers @{"Content-Type" = "application/x-www-form-urlencoded"} `
-        -Body "grant_type=client_credentials&client_id=oneground-000000000&client_secret=<oneground-client-secret>"
-    ```
-
-- Then take an access token from `$response`:
-
-    ```powershell
-    $response.Content
-    ```
-
-##### For Linux, macOS, or WSL (cURL)
-
-- Open terminal and execute this command:
-
-    ```bash
-    curl --location --request POST 'http://localhost:8080/realms/OneGround/protocol/openid-connect/token' \
-    --header 'Content-Type: application/x-www-form-urlencoded' \
-    --data-urlencode 'grant_type=client_credentials' \
-    --data-urlencode 'client_id=oneground-000000000' \
-    --data-urlencode 'client_secret=<oneground-client-secret>'
-    ```
-
-You will receive a JSON response containing the `access_token`. You can now use this token as a `Bearer` token to authorize your API requests.
-
-```json
-{
-    "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAi......",
-    "expires_in": 300,
-    "refresh_expires_in": 0,
-    "token_type": "Bearer"
-}
-```
-
-> **Tip: How to Increase Token Expiration Time**
-> By default, the access token expires in 5 minutes (300 seconds). To increase this time:
->
-> 1. Navigate directly to the **Tokens** settings page in Keycloak: [http://localhost:8080/admin/master/console/#/OneGround/realm-settings/tokens](http://localhost:8080/admin/master/console/#/OneGround/realm-settings/tokens).
-> 2. In the `Access Token Lifespan` field, set a longer duration (e.g., `30 minutes` or `1 hour`).
-> 3. Click **Save**.
->
-> You will need to request a new token for this change to take effect.
+See [AUTHENTICATION.md](../AUTHENTICATION.md).
 
 ### 6. Stopping the Services
 

--- a/localdev/docker-compose.yml
+++ b/localdev/docker-compose.yml
@@ -106,6 +106,13 @@ services:
     networks:
       - oneground
 
+  keycloak-provider-downloader:
+    image: alpine:3.22
+    command: sh -c "if [ -f /providers/zgw-token-introspection.jar ]; then echo 'JAR present'; else wget -q -O /providers/zgw-token-introspection.jar https://github.com/OneGround/Keycloak-ZGW-Token-Introspection/releases/download/v1/zgw-token-introspection.jar && chmod 644 /providers/zgw-token-introspection.jar; fi"
+    volumes:
+      - kc-providers:/providers
+    restart: "no"
+
   keycloak:
     image: quay.io/keycloak/keycloak:26.3.1
     restart: unless-stopped
@@ -130,9 +137,13 @@ services:
       retries: 8
       start_period: 5s
     command: ["start-dev"]
+    volumes:
+      - kc-providers:/opt/keycloak/providers:ro
     depends_on:
       postgres_docker_db:
         condition: service_healthy
+      keycloak-provider-downloader:
+        condition: service_completed_successfully
     networks:
       - oneground
 
@@ -387,6 +398,7 @@ volumes:
   postgres:
   ceph-etc:
   ceph-lib:
+  kc-providers:
 
 networks:
   oneground:

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="CSharpier.MsBuild" Version="1.0.2" />
     <PackageVersion Include="CsvHelper" Version="33.0.1" />
     <PackageVersion Include="Dapper" Version="2.0.123" />
+    <PackageVersion Include="Duende.AspNetCore.Authentication.OAuth2Introspection" Version="6.3.0" />
     <PackageVersion Include="Duende.IdentityModel" Version="7.0.0" />
     <PackageVersion Include="FluentValidation" Version="12.0.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />

--- a/src/OneGround.ZGW.Autorisaties.WebApi/Program.cs
+++ b/src/OneGround.ZGW.Autorisaties.WebApi/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using OneGround.ZGW.Autorisaties.Web;
 using OneGround.ZGW.Autorisaties.Web.Services;
 using OneGround.ZGW.Common.Constants;
+using OneGround.ZGW.Common.Web.Authentication;
 using OneGround.ZGW.Common.Web.Configuration;
 using OneGround.ZGW.Common.Web.Extensions.ServiceCollection;
 

--- a/src/OneGround.ZGW.Besluiten.WebApi/Program.cs
+++ b/src/OneGround.ZGW.Besluiten.WebApi/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using OneGround.ZGW.Autorisaties.ServiceAgent;
 using OneGround.ZGW.Besluiten.Web;
 using OneGround.ZGW.Common.Constants;
+using OneGround.ZGW.Common.Web.Authentication;
 using OneGround.ZGW.Common.Web.Configuration;
 using OneGround.ZGW.Common.Web.Extensions.ServiceCollection;
 

--- a/src/OneGround.ZGW.Catalogi.WebApi/Program.cs
+++ b/src/OneGround.ZGW.Catalogi.WebApi/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using OneGround.ZGW.Autorisaties.ServiceAgent;
 using OneGround.ZGW.Catalogi.Web;
 using OneGround.ZGW.Common.Constants;
+using OneGround.ZGW.Common.Web.Authentication;
 using OneGround.ZGW.Common.Web.Configuration;
 using OneGround.ZGW.Common.Web.Extensions.ServiceCollection;
 

--- a/src/OneGround.ZGW.Common.Web/Authentication/AuthenticationSchemeSelector.cs
+++ b/src/OneGround.ZGW.Common.Web/Authentication/AuthenticationSchemeSelector.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace OneGround.ZGW.Common.Web.Authentication;
+
+public static class AuthenticationSchemeSelector
+{
+    public static string SelectAuthenticationScheme(HttpContext httpContext)
+    {
+        var authHeader = httpContext.Request.Headers.Authorization.ToString();
+        var loggerFactory = httpContext.RequestServices.GetRequiredService<ILoggerFactory>();
+        var logger = loggerFactory.CreateLogger(nameof(AuthenticationSchemeSelector));
+        if (string.IsNullOrWhiteSpace(authHeader))
+        {
+            return ZgwAuthenticationConstants.OAuth2AuthenticationScheme;
+        }
+
+        const string bearerPrefix = "Bearer ";
+        try
+        {
+            var token = authHeader[bearerPrefix.Length..];
+            var handler = new JwtSecurityTokenHandler();
+            var jwt = handler.ReadJwtToken(token);
+            var alg = jwt.Header?.Alg;
+            if (!string.IsNullOrEmpty(alg) && alg.Equals("HS256", StringComparison.OrdinalIgnoreCase))
+            {
+                return ZgwAuthenticationConstants.ZgwTokenIntrospectionAuthenticationScheme;
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogInformation(ex, "Error parsing JWT token in authentication scheme selector");
+        }
+
+        return ZgwAuthenticationConstants.OAuth2AuthenticationScheme;
+    }
+}

--- a/src/OneGround.ZGW.Common.Web/Authentication/ZgwAuthenticationConstants.cs
+++ b/src/OneGround.ZGW.Common.Web/Authentication/ZgwAuthenticationConstants.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+
+namespace OneGround.ZGW.Common.Web.Authentication;
+
+public class ZgwAuthenticationConstants
+{
+    public const string ZgwTokenIntrospectionAuthenticationScheme = "OAuth2Introspection";
+    public const string OAuth2AuthenticationScheme = JwtBearerDefaults.AuthenticationScheme;
+    public const string PolicySelectorAuthenticationScheme = "ZgwAuthenticationSchemeSelector";
+}

--- a/src/OneGround.ZGW.Common.Web/ZGW.Common.Web.csproj
+++ b/src/OneGround.ZGW.Common.Web/ZGW.Common.Web.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Asp.Versioning.Mvc" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" />
     <PackageReference Include="AutoMapper" />
+    <PackageReference Include="Duende.AspNetCore.Authentication.OAuth2Introspection" />
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="MassTransit.RabbitMQ" />

--- a/src/OneGround.ZGW.Documenten.Messaging.Listener/Program.cs
+++ b/src/OneGround.ZGW.Documenten.Messaging.Listener/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using OneGround.ZGW.Common.Configuration;
 using OneGround.ZGW.Common.Constants;
 using OneGround.ZGW.Common.Extensions;
+using OneGround.ZGW.Common.Web.Authentication;
 using OneGround.ZGW.Common.Web.Extensions.ServiceCollection;
 using OneGround.ZGW.Documenten.Messaging;
 

--- a/src/OneGround.ZGW.Documenten.WebApi/Program.cs
+++ b/src/OneGround.ZGW.Documenten.WebApi/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using OneGround.ZGW.Autorisaties.ServiceAgent;
 using OneGround.ZGW.Common.Constants;
+using OneGround.ZGW.Common.Web.Authentication;
 using OneGround.ZGW.Common.Web.Configuration;
 using OneGround.ZGW.Common.Web.Extensions.ServiceCollection;
 using OneGround.ZGW.Documenten.Web;

--- a/src/OneGround.ZGW.Notificaties.WebApi/Program.cs
+++ b/src/OneGround.ZGW.Notificaties.WebApi/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using OneGround.ZGW.Autorisaties.ServiceAgent;
 using OneGround.ZGW.Common.Constants;
+using OneGround.ZGW.Common.Web.Authentication;
 using OneGround.ZGW.Common.Web.Configuration;
 using OneGround.ZGW.Common.Web.Extensions.ServiceCollection;
 using OneGround.ZGW.Notificaties.Web;

--- a/src/OneGround.ZGW.Zaken.WebApi/Program.cs
+++ b/src/OneGround.ZGW.Zaken.WebApi/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using OneGround.ZGW.Autorisaties.ServiceAgent;
 using OneGround.ZGW.Common.Constants;
+using OneGround.ZGW.Common.Web.Authentication;
 using OneGround.ZGW.Common.Web.Configuration;
 using OneGround.ZGW.Common.Web.Extensions.ServiceCollection;
 using OneGround.ZGW.Zaken.Web;

--- a/src/appsettings.Shared.json
+++ b/src/appsettings.Shared.json
@@ -2,7 +2,8 @@
   "Auth": {
     "Authority": "http://localhost:8080/realms/OneGround/",
     "ValidIssuer": "http://localhost:8080/realms/OneGround",
-    "ValidAudience": "account"
+    "ValidAudience": "account",
+    "ZgwTokenIntrospectionEndpoint": "http://localhost:8080/realms/OneGround/zgw-token-introspection/introspect"
   },
   "Services": {
     "ZTC": {


### PR DESCRIPTION
# Pull Request

## Description
Keycloak extension with custom endpoint is used for token introspection and validation. Validation is being done on keycloak side, valid client and realm should already exist.