### PR TITLE
FUND-2575 DRC Make token-renewal recurring job resilient to downtime

### DIFF
--- a/src/OneGround.ZGW.Common/Helpers/CronHelper.cs
+++ b/src/OneGround.ZGW.Common/Helpers/CronHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace OneGround.ZGW.Common.Helpers;
 
@@ -14,6 +15,11 @@ public static class CronHelper
         return $"{targetTime.Minute} {targetTime.Hour} {targetTime.Day} {targetTime.Month} *";
     }
 
+    // Divisors of 60 (excluding 60 itself) in descending order. A "*/N" minute step only fires
+    // on a strictly even cadence when N divides 60 evenly; otherwise the runs bunch up around the
+    // hour boundary (e.g. "*/50" fires at :00 and :50, so the :50 -> :00 gap is only 10 minutes).
+    private static readonly int[] EvenMinuteIntervals = [30, 20, 15, 12, 10, 6, 5, 4, 3, 2, 1];
+
     public static string CreateRecurringMinuteInterval(int maxMinutesBetweenRuns)
     {
         // Generate a *recurring* Cron ("*/N" minute step), as opposed to CreateOneTimeCron
@@ -23,18 +29,16 @@ public static class CronHelper
         // and the job is effectively stuck. A recurring step keeps firing, so Hangfire
         // automatically restarts it shortly after the server recovers.
         //
-        // Note on "*/N" semantics: it does NOT fire at a strictly fixed N-minute cadence. It
-        // fires at minutes 0, N, 2N, ... within each hour and then resets at the top of the
-        // hour, so when N does not divide 60 the runs bunch up around the hour boundary (e.g.
-        // "*/50" fires at :00 and :50, so the :50 -> :00 gap is only 10 minutes). The property
-        // we rely on is the *upper bound*: the gap between consecutive runs never exceeds N
-        // minutes. That is exactly what a renew-before-expiry job needs — bunching only ever
-        // makes the renewal fire sooner, never later, which is harmless. So N is the MAXIMUM
-        // minutes the token may go un-renewed, not a guaranteed exact interval.
-        //
-        // The minute field only supports 0-59, so clamp to [1, 59]. Renewing a little more
-        // often than strictly required is harmless; never renewing is what breaks these jobs.
-        var interval = Math.Clamp(maxMinutesBetweenRuns, 1, 59);
+        // Snap the interval to the largest divisor of 60 that is <= maxMinutesBetweenRuns. This
+        // gives two guarantees:
+        //   1. The chosen N divides 60, so "*/N" fires on a strictly even cadence (no bunching
+        //      around the hour boundary).
+        //   2. We round DOWN, never up, so the gap between runs never exceeds the requested
+        //      maximum — the token is always renewed before it expires. Renewing a little more
+        //      often than strictly required is harmless; never renewing is what breaks the job.
+        // Values below 1 fall back to every minute. The effective ceiling is 30 minutes (the
+        // largest divisor of 60 below 60), which is well within any realistic token lifetime.
+        var interval = EvenMinuteIntervals.FirstOrDefault(d => d <= maxMinutesBetweenRuns, 1);
 
         // Format: Minute Hour DayOfMonth Month DayOfWeek
         return $"*/{interval} * * * *";

--- a/src/OneGround.ZGW.Common/Helpers/CronHelper.cs
+++ b/src/OneGround.ZGW.Common/Helpers/CronHelper.cs
@@ -13,4 +13,23 @@ public static class CronHelper
         // Format: Minute Hour DayOfMonth Month DayOfWeek
         return $"{targetTime.Minute} {targetTime.Hour} {targetTime.Day} {targetTime.Month} *";
     }
+
+    public static string CreateRecurringMinuteInterval(int intervalInMinutes)
+    {
+        // Generate a *recurring* Cron that fires every N minutes (a "*/N" minute step),
+        // as opposed to CreateOneTimeCron which matches a single instant. A one-time cron
+        // is fragile: if its single matching instant is missed (the Hangfire server is down,
+        // e.g. during a Consul key rotation) or the run fails after exhausting its retries,
+        // the next occurrence is ~a year away and the job is effectively stuck. A recurring
+        // interval keeps firing on a fixed cadence, so Hangfire automatically restarts it
+        // shortly after the server recovers.
+        //
+        // The minute field only supports 0-59, so clamp the interval to [1, 59]. Renewing a
+        // little more often than strictly required is harmless; never renewing is what breaks
+        // the token-renewal jobs.
+        var interval = Math.Clamp(intervalInMinutes, 1, 59);
+
+        // Format: Minute Hour DayOfMonth Month DayOfWeek
+        return $"*/{interval} * * * *";
+    }
 }

--- a/src/OneGround.ZGW.Common/Helpers/CronHelper.cs
+++ b/src/OneGround.ZGW.Common/Helpers/CronHelper.cs
@@ -14,20 +14,27 @@ public static class CronHelper
         return $"{targetTime.Minute} {targetTime.Hour} {targetTime.Day} {targetTime.Month} *";
     }
 
-    public static string CreateRecurringMinuteInterval(int intervalInMinutes)
+    public static string CreateRecurringMinuteInterval(int maxMinutesBetweenRuns)
     {
-        // Generate a *recurring* Cron that fires every N minutes (a "*/N" minute step),
-        // as opposed to CreateOneTimeCron which matches a single instant. A one-time cron
-        // is fragile: if its single matching instant is missed (the Hangfire server is down,
-        // e.g. during a Consul key rotation) or the run fails after exhausting its retries,
-        // the next occurrence is ~a year away and the job is effectively stuck. A recurring
-        // interval keeps firing on a fixed cadence, so Hangfire automatically restarts it
-        // shortly after the server recovers.
+        // Generate a *recurring* Cron ("*/N" minute step), as opposed to CreateOneTimeCron
+        // which matches a single instant. A one-time cron is fragile: if its single matching
+        // instant is missed (the Hangfire server is down, e.g. during a Consul key rotation)
+        // or the run fails after exhausting its retries, the next occurrence is ~a year away
+        // and the job is effectively stuck. A recurring step keeps firing, so Hangfire
+        // automatically restarts it shortly after the server recovers.
         //
-        // The minute field only supports 0-59, so clamp the interval to [1, 59]. Renewing a
-        // little more often than strictly required is harmless; never renewing is what breaks
-        // the token-renewal jobs.
-        var interval = Math.Clamp(intervalInMinutes, 1, 59);
+        // Note on "*/N" semantics: it does NOT fire at a strictly fixed N-minute cadence. It
+        // fires at minutes 0, N, 2N, ... within each hour and then resets at the top of the
+        // hour, so when N does not divide 60 the runs bunch up around the hour boundary (e.g.
+        // "*/50" fires at :00 and :50, so the :50 -> :00 gap is only 10 minutes). The property
+        // we rely on is the *upper bound*: the gap between consecutive runs never exceeds N
+        // minutes. That is exactly what a renew-before-expiry job needs — bunching only ever
+        // makes the renewal fire sooner, never later, which is harmless. So N is the MAXIMUM
+        // minutes the token may go un-renewed, not a guaranteed exact interval.
+        //
+        // The minute field only supports 0-59, so clamp to [1, 59]. Renewing a little more
+        // often than strictly required is harmless; never renewing is what breaks these jobs.
+        var interval = Math.Clamp(maxMinutesBetweenRuns, 1, 59);
 
         // Format: Minute Hour DayOfMonth Month DayOfWeek
         return $"*/{interval} * * * *";

--- a/src/OneGround.ZGW.Documenten.Jobs/Subscription/CreateOrPatchSubscriptionJob.cs
+++ b/src/OneGround.ZGW.Documenten.Jobs/Subscription/CreateOrPatchSubscriptionJob.cs
@@ -153,13 +153,17 @@ public class CreateOrPatchSubscriptionJob : SubscriptionJobBase<CreateOrPatchSub
                 }
             }
 
-            // Create a recurring job to renew the token before it expires (use ExpiresMinutesBefore)
+            // Keep the recurring job renewing the token before it expires (use ExpiresMinutesBefore).
+            // Use a *recurring* interval cron, not a one-time cron: a one-time cron describes a single
+            // instant, so a missed run during downtime (e.g. a key rotation) or a run that fails after its
+            // retries leaves the job stuck for ~a year. A recurring interval keeps firing, so Hangfire
+            // automatically restarts the renewal shortly after the server recovers.
             double refreshInMinutes =
                 token.expiresIn.TotalMinutes >= ExpiresMinutesBefore
                     ? Math.Max(1, (int)Math.Floor(token.expiresIn.TotalMinutes - ExpiresMinutesBefore))
                     : Math.Max(1, (int)Math.Floor(token.expiresIn.TotalMinutes / 2));
 
-            var refreshCronExpression = CronHelper.CreateOneTimeCron((int)refreshInMinutes);
+            var refreshCronExpression = CronHelper.CreateRecurringMinuteInterval((int)refreshInMinutes);
             RecurringJob.AddOrUpdate<CreateOrPatchSubscriptionJob>(GetJobId(rsin), h => h.ExecuteAsync(rsin), refreshCronExpression);
         }
 

--- a/src/Tests/OneGround.ZGW.Common.UnitTests/CronHelperTests.cs
+++ b/src/Tests/OneGround.ZGW.Common.UnitTests/CronHelperTests.cs
@@ -1,4 +1,5 @@
-﻿using OneGround.ZGW.Common.Helpers;
+﻿using System.Globalization;
+using OneGround.ZGW.Common.Helpers;
 using Xunit;
 
 namespace OneGround.OneGround.ZGW.Common.UnitTests;
@@ -6,45 +7,95 @@ namespace OneGround.OneGround.ZGW.Common.UnitTests;
 public class CronHelperTests
 {
     [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(5, 5)]
+    [InlineData(10, 10)]
+    [InlineData(30, 30)]
+    public void CreateRecurringMinuteInterval_WhenValueIsADivisorOf60_KeepsIt(int maxMinutes, int expected)
+    {
+        // Act
+        var cron = CronHelper.CreateRecurringMinuteInterval(maxMinutes);
+
+        // Assert
+        Assert.Equal($"*/{expected} * * * *", cron);
+    }
+
+    [Theory]
+    [InlineData(7, 6)]
+    [InlineData(11, 10)]
+    [InlineData(13, 12)]
+    [InlineData(25, 20)]
+    [InlineData(50, 30)] // the ~60-min token / refreshInMinutes=50 case Copilot flagged
+    [InlineData(59, 30)]
+    public void CreateRecurringMinuteInterval_WhenValueIsNotADivisor_RoundsDownToNearestDivisor(int maxMinutes, int expected)
+    {
+        // Act
+        var cron = CronHelper.CreateRecurringMinuteInterval(maxMinutes);
+
+        // Assert
+        Assert.Equal($"*/{expected} * * * *", cron);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-10)]
+    public void CreateRecurringMinuteInterval_WhenValueBelowOne_FallsBackToEveryMinute(int maxMinutes)
+    {
+        // Act
+        var cron = CronHelper.CreateRecurringMinuteInterval(maxMinutes);
+
+        // Assert
+        Assert.Equal("*/1 * * * *", cron);
+    }
+
+    [Theory]
+    [InlineData(31)]
+    [InlineData(60)]
+    [InlineData(1440)]
+    public void CreateRecurringMinuteInterval_WhenValueAboveCeiling_CapsAtThirtyMinutes(int maxMinutes)
+    {
+        // Act
+        var cron = CronHelper.CreateRecurringMinuteInterval(maxMinutes);
+
+        // Assert
+        Assert.Equal("*/30 * * * *", cron);
+    }
+
+    [Theory]
     [InlineData(1)]
-    [InlineData(5)]
+    [InlineData(7)]
+    [InlineData(13)]
+    [InlineData(25)]
     [InlineData(50)]
     [InlineData(59)]
-    public void CreateRecurringMinuteInterval_WithValidInterval_ReturnsRecurringStepCron(int interval)
+    public void CreateRecurringMinuteInterval_AlwaysProducesAnEvenCadence(int maxMinutes)
     {
-        // Act
-        var cron = CronHelper.CreateRecurringMinuteInterval(interval);
+        // The chosen step must divide 60 evenly, otherwise "*/N" bunches runs around the hour
+        // boundary. Parse N back out of the cron string and assert 60 % N == 0.
+        var cron = CronHelper.CreateRecurringMinuteInterval(maxMinutes);
 
-        // Assert
-        Assert.Equal($"*/{interval} * * * *", cron);
+        var step = int.Parse(cron.Substring("*/".Length, cron.IndexOf(' ') - "*/".Length), CultureInfo.InvariantCulture);
+        Assert.Equal(0, 60 % step);
     }
 
     [Theory]
-    [InlineData(0, 1)]
-    [InlineData(-10, 1)]
-    public void CreateRecurringMinuteInterval_WithIntervalBelowOne_ClampsToOne(int interval, int expected)
+    [InlineData(7, 6)]
+    [InlineData(50, 30)]
+    [InlineData(59, 30)]
+    public void CreateRecurringMinuteInterval_NeverExceedsTheRequestedMaximum(int maxMinutes, int expectedAtMost)
     {
-        // Act
-        var cron = CronHelper.CreateRecurringMinuteInterval(interval);
+        // Rounding down guarantees the gap between runs never exceeds the requested maximum,
+        // so the token is always renewed before expiry.
+        var cron = CronHelper.CreateRecurringMinuteInterval(maxMinutes);
 
-        // Assert
-        Assert.Equal($"*/{expected} * * * *", cron);
-    }
-
-    [Theory]
-    [InlineData(60, 59)]
-    [InlineData(1440, 59)]
-    public void CreateRecurringMinuteInterval_WithIntervalAboveFiftyNine_ClampsToFiftyNine(int interval, int expected)
-    {
-        // Act
-        var cron = CronHelper.CreateRecurringMinuteInterval(interval);
-
-        // Assert
-        Assert.Equal($"*/{expected} * * * *", cron);
+        var step = int.Parse(cron.Substring("*/".Length, cron.IndexOf(' ') - "*/".Length), CultureInfo.InvariantCulture);
+        Assert.True(step <= maxMinutes);
+        Assert.Equal(expectedAtMost, step);
     }
 
     [Fact]
-    public void CreateRecurringMinuteInterval_AlwaysProducesAStepMinuteCron_NotAOneTimeInstant()
+    public void CreateRecurringMinuteInterval_ProducesAStepMinuteCron_NotAOneTimeInstant()
     {
         // A recurring cron uses a "*/N" minute step and wildcards for the remaining fields, so it
         // fires repeatedly. A one-time cron pins concrete minute/hour/day/month values. This guards

--- a/src/Tests/OneGround.ZGW.Common.UnitTests/CronHelperTests.cs
+++ b/src/Tests/OneGround.ZGW.Common.UnitTests/CronHelperTests.cs
@@ -1,0 +1,57 @@
+﻿using OneGround.ZGW.Common.Helpers;
+using Xunit;
+
+namespace OneGround.OneGround.ZGW.Common.UnitTests;
+
+public class CronHelperTests
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(50)]
+    [InlineData(59)]
+    public void CreateRecurringMinuteInterval_WithValidInterval_ReturnsRecurringStepCron(int interval)
+    {
+        // Act
+        var cron = CronHelper.CreateRecurringMinuteInterval(interval);
+
+        // Assert
+        Assert.Equal($"*/{interval} * * * *", cron);
+    }
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(-10, 1)]
+    public void CreateRecurringMinuteInterval_WithIntervalBelowOne_ClampsToOne(int interval, int expected)
+    {
+        // Act
+        var cron = CronHelper.CreateRecurringMinuteInterval(interval);
+
+        // Assert
+        Assert.Equal($"*/{expected} * * * *", cron);
+    }
+
+    [Theory]
+    [InlineData(60, 59)]
+    [InlineData(1440, 59)]
+    public void CreateRecurringMinuteInterval_WithIntervalAboveFiftyNine_ClampsToFiftyNine(int interval, int expected)
+    {
+        // Act
+        var cron = CronHelper.CreateRecurringMinuteInterval(interval);
+
+        // Assert
+        Assert.Equal($"*/{expected} * * * *", cron);
+    }
+
+    [Fact]
+    public void CreateRecurringMinuteInterval_AlwaysProducesAStepMinuteCron_NotAOneTimeInstant()
+    {
+        // A recurring cron uses a "*/N" minute step and wildcards for the remaining fields, so it
+        // fires repeatedly. A one-time cron pins concrete minute/hour/day/month values. This guards
+        // against accidentally regressing back to the fragile one-time behaviour.
+        var recurring = CronHelper.CreateRecurringMinuteInterval(15);
+
+        Assert.StartsWith("*/", recurring);
+        Assert.EndsWith(" * * * *", recurring);
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

CreateOrPatchSubscriptionJob rescheduled itself with a one-time cron, which describes a single instant. If that instant was missed because the Hangfire server was down (e.g. a Consul encryption key rotation) or the run failed after exhausting its retries, the next matching occurrence was ~a year away and the self-renewal chain was stuck; the bearer token then expired and DRC notifications failed.

Add CronHelper.CreateRecurringMinuteInterval, which builds a recurring "*/N" minute-step cron (clamped to a valid 1-59 minute field), and use it for the renewal job so Hangfire keeps firing on a fixed cadence and restarts the renewal automatically after the server recovers. Covered by new CronHelper unit tests.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Related Issues

<!-- Link to issues: Fixes #123 -->

## Testing

- [x] Tests pass
- [ ] Manual testing completed

## Checklist

- [ ] Self-review completed
- [ ] Documentation updated (if needed)
