### PR TITLE
FUND-2576 NRC: circuit breaker with auto-block for failing subscriptions

### DIFF
--- a/src/OneGround.ZGW.Notificaties.DataModel/Abonnement.cs
+++ b/src/OneGround.ZGW.Notificaties.DataModel/Abonnement.cs
@@ -26,5 +26,8 @@ public class Abonnement : OwnedEntity, IBaseEntity, IUrlEntity
     [MaxLength(8192)]
     public string Auth { get; set; }
 
+    [Column("blocked")]
+    public bool Blocked { get; set; }
+
     public IList<AbonnementKanaal> AbonnementKanalen { get; set; }
 }

--- a/src/OneGround.ZGW.Notificaties.DataModel/Migrations/20260611121808_add_blocked_to_abonnementen.Designer.cs
+++ b/src/OneGround.ZGW.Notificaties.DataModel/Migrations/20260611121808_add_blocked_to_abonnementen.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using OneGround.ZGW.Notificaties.DataModel;
@@ -11,9 +12,11 @@ using OneGround.ZGW.Notificaties.DataModel;
 namespace OneGround.ZGW.Notificaties.DataModel.Migrations
 {
     [DbContext(typeof(NrcDbContext))]
-    partial class NrcDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260611121808_add_blocked_to_abonnementen")]
+    partial class add_blocked_to_abonnementen
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/OneGround.ZGW.Notificaties.DataModel/Migrations/20260611121808_add_blocked_to_abonnementen.cs
+++ b/src/OneGround.ZGW.Notificaties.DataModel/Migrations/20260611121808_add_blocked_to_abonnementen.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace OneGround.ZGW.Notificaties.DataModel.Migrations
+{
+    /// <inheritdoc />
+    public partial class add_blocked_to_abonnementen : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(name: "blocked", table: "abonnementen", type: "boolean", nullable: false, defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "blocked", table: "abonnementen");
+        }
+    }
+}

--- a/src/OneGround.ZGW.Notificaties.Messaging.Listener/appsettings.json
+++ b/src/OneGround.ZGW.Notificaties.Messaging.Listener/appsettings.json
@@ -26,12 +26,14 @@
   "Hangfire": {
     "RetrySchedule": "0.00:15;0.00:30;0.01:00;0.04:00;1.00:00",
     "ExpireFailedJobsScanAt": "05:00",
-    "ExpireFailedJobAfter": "7.00:00"
+    "ExpireFailedJobAfter": "7.00:00",
+    "BlockFailingSubscriptionsScanCron": "0 * * * *"
   },
   "CircuitBreaker": {
     "FailureThreshold": 3,
     "BreakDuration": "00:05:00",
-    "CacheExpirationMinutes": 10
+    "CacheExpirationMinutes": 10,
+    "BlockSubscriptionAfter": "7.00:00:00"
   },
   "Application": {
     "CallbackTimeout": "00:01:40",

--- a/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/CircuitBreakerCacheKeys.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/CircuitBreakerCacheKeys.cs
@@ -1,0 +1,11 @@
+namespace OneGround.ZGW.Notificaties.Messaging.CircuitBreaker;
+
+public static class CircuitBreakerCacheKeys
+{
+    public const string SubscriberPrefix = "ZGW:NRC:CircuitBreaker:subscriber:";
+    public const string FailingSincePrefix = "ZGW:NRC:CircuitBreaker:failing-since:";
+
+    public static string ForSubscriber(Guid abonnementId) => $"{SubscriberPrefix}{abonnementId}";
+
+    public static string ForFailingSince(Guid abonnementId) => $"{FailingSincePrefix}{abonnementId}";
+}

--- a/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/Extensions/CircuitBreakerServiceCollectionExtensions.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/Extensions/CircuitBreakerServiceCollectionExtensions.cs
@@ -13,6 +13,18 @@ public static class CircuitBreakerServiceCollectionExtensions
             .AddOptions<CircuitBreakerOptions>()
             .Bind(configuration.GetSection(CircuitBreakerOptions.CircuitBreaker))
             .ValidateDataAnnotations()
+            .Validate(
+                o => o.BreakDuration > TimeSpan.Zero,
+                $"{CircuitBreakerOptions.CircuitBreaker}: {nameof(CircuitBreakerOptions.BreakDuration)} must be greater than zero."
+            )
+            .Validate(
+                o => TimeSpan.FromMinutes(o.CacheExpirationMinutes) > o.BreakDuration,
+                $"{CircuitBreakerOptions.CircuitBreaker}: {nameof(CircuitBreakerOptions.CacheExpirationMinutes)} must exceed {nameof(CircuitBreakerOptions.BreakDuration)} so an open circuit survives until its half-open transition."
+            )
+            .Validate(
+                o => o.BlockSubscriptionAfter > o.BreakDuration,
+                $"{CircuitBreakerOptions.CircuitBreaker}: {nameof(CircuitBreakerOptions.BlockSubscriptionAfter)} must be greater than {nameof(CircuitBreakerOptions.BreakDuration)}."
+            )
             .ValidateOnStart();
 
         services.AddSingleton<ICircuitBreakerSubscriberHealthTracker, RedisCircuitBreakerSubscriberHealthTracker>();

--- a/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/Models/CircuitBreakerSubscriberHealthState.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/Models/CircuitBreakerSubscriberHealthState.cs
@@ -3,6 +3,11 @@
 public class CircuitBreakerSubscriberHealthState
 {
     /// <summary>
+    /// The subscription (abonnement) this health state tracks.
+    /// </summary>
+    public Guid AbonnementId { get; set; }
+
+    /// <summary>
     /// The subscriber URL that this health state tracks.
     /// </summary>
     public string Url { get; set; } = string.Empty;

--- a/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/Options/CircuitBreakerOptions.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/Options/CircuitBreakerOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 namespace OneGround.ZGW.Notificaties.Messaging.CircuitBreaker.Options;
 
@@ -22,8 +22,24 @@ public class CircuitBreakerOptions
 
     /// <summary>
     /// Duration to cache subscriber health state in Redis before automatic expiration and recovery.
+    /// Must exceed BreakDuration so an open circuit survives until its half-open transition.
     /// Default: 10 minutes.
     /// </summary>
     [Range(1, 60)]
     public int CacheExpirationMinutes { get; set; } = 10;
+
+    /// <summary>
+    /// Continuous-failure duration after which the subscription is permanently blocked in the database.
+    /// The subscription can be unblocked again via the management API.
+    /// Default: 7 days.
+    /// </summary>
+    [Required]
+    public TimeSpan BlockSubscriptionAfter { get; set; } = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// Time-to-live of the failing-since marker that tracks the long-term failure window. Must
+    /// outlive the longest gap between delivery attempts (retry schedule goes up to 1 day) so the
+    /// window keeps accumulating across breaker open/half-open cycles.
+    /// </summary>
+    public TimeSpan FailingSinceMarkerExpiration => BlockSubscriptionAfter + TimeSpan.FromDays(1);
 }

--- a/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/Services/ICircuitBreakerSubscriberHealthTracker.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/Services/ICircuitBreakerSubscriberHealthTracker.cs
@@ -26,40 +26,63 @@ public interface ICircuitBreakerSubscriberHealthTracker
     /// <summary>
     /// Checks if a subscriber endpoint is healthy and available to receive notifications.
     /// </summary>
-    /// <param name="url">The subscriber URL to check.</param>
+    /// <param name="abonnementId">The subscription (abonnement) to check.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>True if the subscriber is healthy (circuit closed), false if unhealthy (circuit open).</returns>
-    Task<bool> IsHealthyAsync(string url, CancellationToken cancellationToken = default);
+    Task<bool> IsHealthyAsync(Guid abonnementId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Marks a subscriber as unhealthy after a failure, incrementing the failure count.
     /// Opens the circuit if failure threshold is reached.
     /// </summary>
-    /// <param name="url">The subscriber URL that failed.</param>
+    /// <param name="abonnementId">The subscription (abonnement) that failed.</param>
+    /// <param name="url">The subscriber URL (display only, kept in log messages).</param>
     /// <param name="errorMessage">Optional error message from the failure.</param>
     /// <param name="statusCode">Optional HTTP status code from the failure.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task MarkUnhealthyAsync(string url, string? errorMessage = null, int? statusCode = null, CancellationToken cancellationToken = default);
+    Task MarkUnhealthyAsync(
+        Guid abonnementId,
+        string url,
+        string? errorMessage = null,
+        int? statusCode = null,
+        CancellationToken cancellationToken = default
+    );
 
     /// <summary>
     /// Marks a subscriber as healthy, resetting the failure count and closing the circuit.
     /// </summary>
-    /// <param name="url">The subscriber URL that succeeded.</param>
+    /// <param name="abonnementId">The subscription (abonnement) that succeeded.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task MarkHealthyAsync(string url, CancellationToken cancellationToken = default);
+    Task MarkHealthyAsync(Guid abonnementId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the current health state of a subscriber.
     /// </summary>
-    /// <param name="url">The subscriber URL to query.</param>
+    /// <param name="abonnementId">The subscription (abonnement) to query.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The health state, or null if no state is tracked.</returns>
-    Task<CircuitBreakerSubscriberHealthState?> GetHealthStateAsync(string url, CancellationToken cancellationToken = default);
+    Task<CircuitBreakerSubscriberHealthState?> GetHealthStateAsync(Guid abonnementId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Resets the health state of a subscriber, clearing all failure history.
     /// </summary>
-    /// <param name="url">The subscriber URL to reset.</param>
+    /// <param name="abonnementId">The subscription (abonnement) to reset.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    Task ResetHealthAsync(string url, CancellationToken cancellationToken = default);
+    Task ResetHealthAsync(Guid abonnementId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Records the start of a subscription's long-term failure window (set-once). Writes the
+    /// failing-since marker only when it is absent; a no-op when it already exists so the window
+    /// keeps accumulating across breaker open/half-open cycles.
+    /// </summary>
+    /// <param name="abonnementId">The subscription (abonnement) that failed.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task EnsureFailingSinceAsync(Guid abonnementId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Clears the failing-since marker (e.g. after a successful delivery resets the long-term window).
+    /// </summary>
+    /// <param name="abonnementId">The subscription (abonnement) that recovered.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task ClearFailingSinceAsync(Guid abonnementId, CancellationToken cancellationToken = default);
 }

--- a/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/Services/RedisCircuitBreakerSubscriberHealthTracker.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/Services/RedisCircuitBreakerSubscriberHealthTracker.cs
@@ -1,9 +1,9 @@
-using System.Security.Cryptography;
-using System.Text;
+using System.Globalization;
 using System.Text.Json;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OneGround.ZGW.Notificaties.Messaging.CircuitBreaker;
 using OneGround.ZGW.Notificaties.Messaging.CircuitBreaker.Models;
 using OneGround.ZGW.Notificaties.Messaging.CircuitBreaker.Options;
 using StackExchange.Redis;
@@ -14,23 +14,19 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
     IDistributedCache cache,
     ILogger<RedisCircuitBreakerSubscriberHealthTracker> logger,
     IOptions<CircuitBreakerOptions> circuitBreakerOptions,
-    ConfigurationOptions configurationOptions
+    IConnectionMultiplexer connectionMultiplexer
 ) : ICircuitBreakerSubscriberHealthTracker
 {
-    private const string CacheKeyPrefix = "ZGW:NRC:CircuitBreaker:subscriber:";
-
     public async Task<IDictionary<RedisKey, CircuitBreakerSubscriberHealthState>> GetAllUnhealthyAsync(CancellationToken cancellationToken = default)
     {
-        using ConnectionMultiplexer redis = ConnectionMultiplexer.Connect(configurationOptions);
+        IDatabase db = connectionMultiplexer.GetDatabase();
 
-        IDatabase db = redis.GetDatabase();
-
-        var endpoint = redis.GetEndPoints()[0];
-        IServer server = redis.GetServer(endpoint);
+        var endpoint = connectionMultiplexer.GetEndPoints()[0];
+        IServer server = connectionMultiplexer.GetServer(endpoint);
 
         var results = new Dictionary<RedisKey, CircuitBreakerSubscriberHealthState>();
 
-        foreach (var key in server.Keys(pattern: $"{CacheKeyPrefix}*"))
+        foreach (var key in server.Keys(pattern: $"{CircuitBreakerCacheKeys.SubscriberPrefix}*"))
         {
             if (key == default(RedisKey))
             {
@@ -95,11 +91,11 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
         }
     }
 
-    public async Task<bool> IsHealthyAsync(string url, CancellationToken cancellationToken = default)
+    public async Task<bool> IsHealthyAsync(Guid abonnementId, CancellationToken cancellationToken = default)
     {
         try
         {
-            var state = await GetHealthStateAsync(url, cancellationToken);
+            var state = await GetHealthStateAsync(abonnementId, cancellationToken);
 
             if (state == null)
             {
@@ -110,14 +106,14 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
             // Check if circuit should transition from Open to Half-Open (monitoring)
             if (state.BlockedUntil.HasValue && DateTime.UtcNow >= state.BlockedUntil.Value)
             {
-                // Transition to half-open state - clear BlockedUntil and reset counters
-                // The presence of state with ConsecutiveFailures > 0 will indicate we're monitoring
-                logger.LogInformation(
-                    "Circuit breaker transitioned to HALF-OPEN for subscriber '{Url}'. Monitoring for recovery. Failure counters reset.",
-                    url
-                );
+                // Transition to half-open: drop the breaker state and allow one trial attempt.
+                await ResetHealthAsync(abonnementId, cancellationToken);
 
-                await MarkHealthyAsync(url, cancellationToken);
+                logger.LogInformation(
+                    "Circuit breaker transitioned to HALF-OPEN for subscription {AbonnementId} ('{Url}'). Monitoring for recovery.",
+                    state.AbonnementId,
+                    state.Url
+                );
 
                 return true; // Allow one attempt
             }
@@ -127,9 +123,10 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
             if (!isHealthy)
             {
                 logger.LogWarning(
-                    "Subscriber health check failed: Circuit is OPEN for '{Url}'. "
+                    "Subscriber health check failed: Circuit is OPEN for subscription {AbonnementId} ('{Url}'). "
                         + "Blocked until {BlockedUntil}. Consecutive failures: {ConsecutiveFailures}",
-                    url,
+                    state.AbonnementId,
+                    state.Url,
                     state.BlockedUntil,
                     state.ConsecutiveFailures
                 );
@@ -139,13 +136,14 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error checking subscriber health for '{Url}'. Treating as healthy (fail-open).", url);
+            logger.LogError(ex, "Error checking subscriber health for subscription {AbonnementId}. Treating as healthy (fail-open).", abonnementId);
             // Fail-open: if we can't check health, allow the notification through
             return true;
         }
     }
 
     public async Task MarkUnhealthyAsync(
+        Guid abonnementId,
         string url,
         string? errorMessage = null,
         int? statusCode = null,
@@ -154,7 +152,9 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
     {
         try
         {
-            var state = await GetHealthStateAsync(url, cancellationToken) ?? new CircuitBreakerSubscriberHealthState { Url = url };
+            var state =
+                await GetHealthStateAsync(abonnementId, cancellationToken)
+                ?? new CircuitBreakerSubscriberHealthState { AbonnementId = abonnementId, Url = url };
 
             // Detect if we're failing during HALF-OPEN (monitoring) state:
             // State exists, BlockedUntil is null, and we have a low failure count
@@ -181,9 +181,10 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
                 if (wasInHalfOpen)
                 {
                     logger.LogWarning(
-                        "Circuit breaker RE-OPENED for subscriber '{Url}'. "
+                        "Circuit breaker RE-OPENED for subscription {AbonnementId} ('{Url}'). "
                             + "Failed again during monitoring. Consecutive failures: {ConsecutiveFailures}. "
                             + "Blocked until {BlockedUntil}. Last error: {ErrorMessage}",
+                        abonnementId,
                         url,
                         state.ConsecutiveFailures,
                         state.BlockedUntil,
@@ -193,9 +194,10 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
                 else
                 {
                     logger.LogWarning(
-                        "Circuit breaker OPENED for subscriber '{Url}'. "
+                        "Circuit breaker OPENED for subscription {AbonnementId} ('{Url}'). "
                             + "Failure threshold reached: {ConsecutiveFailures}/{FailureThreshold}. "
                             + "Blocked until {BlockedUntil}. Last error: {ErrorMessage}",
+                        abonnementId,
                         url,
                         state.ConsecutiveFailures,
                         circuitBreakerOptions.Value.FailureThreshold,
@@ -207,8 +209,9 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
             else
             {
                 logger.LogInformation(
-                    "Subscriber '{Url}' marked as unhealthy. Consecutive failures: {ConsecutiveFailures}/{FailureThreshold}. "
+                    "Subscription {AbonnementId} ('{Url}') marked as unhealthy. Consecutive failures: {ConsecutiveFailures}/{FailureThreshold}. "
                         + "Last error: {ErrorMessage}",
+                    abonnementId,
                     url,
                     state.ConsecutiveFailures,
                     circuitBreakerOptions.Value.FailureThreshold,
@@ -217,21 +220,22 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
             }
 
             await SaveHealthStateAsync(state, cancellationToken);
+            await EnsureFailingSinceAsync(abonnementId, cancellationToken);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error marking subscriber '{Url}' as unhealthy. Health tracking may be inconsistent.", url);
+            logger.LogError(ex, "Error marking subscription {AbonnementId} as unhealthy. Health tracking may be inconsistent.", abonnementId);
         }
     }
 
-    public async Task MarkHealthyAsync(string url, CancellationToken cancellationToken = default)
+    public async Task MarkHealthyAsync(Guid abonnementId, CancellationToken cancellationToken = default)
     {
         try
         {
-            var state = await GetHealthStateAsync(url, cancellationToken);
+            var state = await GetHealthStateAsync(abonnementId, cancellationToken);
             if (state == null)
             {
-                // Already healthy, nothing to do
+                await ClearFailingSinceAsync(abonnementId, cancellationToken);
                 return;
             }
 
@@ -239,32 +243,37 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
             var previousFailures = state.ConsecutiveFailures;
 
             // Remove the health state (healthy = no tracking needed)
-            await ResetHealthAsync(url, cancellationToken);
+            await ResetHealthAsync(abonnementId, cancellationToken);
+            await ClearFailingSinceAsync(abonnementId, cancellationToken);
 
             if (wasCircuitOpen)
             {
                 logger.LogInformation(
-                    "Circuit breaker CLOSED for subscriber '{Url}'. " + "Subscriber recovered after {ConsecutiveFailures} failures.",
-                    url,
+                    "Circuit breaker CLOSED for subscription {AbonnementId}. " + "Subscriber recovered after {ConsecutiveFailures} failures.",
+                    abonnementId,
                     previousFailures
                 );
             }
             else if (previousFailures > 0)
             {
-                logger.LogInformation("Subscriber '{Url}' marked as healthy. Failure count reset from {PreviousFailures}.", url, previousFailures);
+                logger.LogInformation(
+                    "Subscription {AbonnementId} marked as healthy. Failure count reset from {PreviousFailures}.",
+                    abonnementId,
+                    previousFailures
+                );
             }
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error marking subscriber '{Url}' as healthy. Health tracking may be inconsistent.", url);
+            logger.LogError(ex, "Error marking subscription {AbonnementId} as healthy. Health tracking may be inconsistent.", abonnementId);
         }
     }
 
-    public async Task<CircuitBreakerSubscriberHealthState?> GetHealthStateAsync(string url, CancellationToken cancellationToken = default)
+    public async Task<CircuitBreakerSubscriberHealthState?> GetHealthStateAsync(Guid abonnementId, CancellationToken cancellationToken = default)
     {
         try
         {
-            var cacheKey = GetCacheKey(url);
+            var cacheKey = GetCacheKey(abonnementId);
             var cachedData = await cache.GetStringAsync(cacheKey, cancellationToken);
 
             if (string.IsNullOrEmpty(cachedData))
@@ -276,29 +285,54 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error retrieving health state for subscriber '{Url}'.", url);
+            logger.LogError(ex, "Error retrieving health state for subscription {AbonnementId}.", abonnementId);
             return null;
         }
     }
 
-    public async Task ResetHealthAsync(string url, CancellationToken cancellationToken = default)
+    public async Task ResetHealthAsync(Guid abonnementId, CancellationToken cancellationToken = default)
     {
         try
         {
-            var cacheKey = GetCacheKey(url);
+            var cacheKey = GetCacheKey(abonnementId);
             await cache.RemoveAsync(cacheKey, cancellationToken);
 
-            logger.LogInformation("Health state reset for subscriber '{Url}'.", url);
+            logger.LogInformation("Health state reset for subscription {AbonnementId}.", abonnementId);
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Error resetting health state for subscriber '{Url}'.", url);
+            logger.LogError(ex, "Error resetting health state for subscription {AbonnementId}.", abonnementId);
         }
+    }
+
+    public async Task EnsureFailingSinceAsync(Guid abonnementId, CancellationToken cancellationToken = default)
+    {
+        var markerKey = CircuitBreakerCacheKeys.ForFailingSince(abonnementId);
+
+        var existing = await cache.GetStringAsync(markerKey, cancellationToken);
+        if (existing != null && DateTime.TryParse(existing, null, DateTimeStyles.RoundtripKind, out _))
+        {
+            // Set-once: the long-term failure window keeps accumulating across breaker open/half-open cycles.
+            return;
+        }
+
+        var options = new DistributedCacheEntryOptions
+        {
+            // Must outlive the longest gap between delivery attempts (retry schedule goes up
+            // to 1 day) so the window keeps accumulating across breaker cycles.
+            AbsoluteExpirationRelativeToNow = circuitBreakerOptions.Value.FailingSinceMarkerExpiration,
+        };
+        await cache.SetStringAsync(markerKey, DateTime.UtcNow.ToString("O"), options, cancellationToken);
+    }
+
+    public async Task ClearFailingSinceAsync(Guid abonnementId, CancellationToken cancellationToken = default)
+    {
+        await cache.RemoveAsync(CircuitBreakerCacheKeys.ForFailingSince(abonnementId), cancellationToken);
     }
 
     private async Task SaveHealthStateAsync(CircuitBreakerSubscriberHealthState state, CancellationToken cancellationToken)
     {
-        var cacheKey = GetCacheKey(state.Url);
+        var cacheKey = GetCacheKey(state.AbonnementId);
         var serialized = JsonSerializer.Serialize(state);
 
         var options = new DistributedCacheEntryOptions
@@ -309,13 +343,5 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
         await cache.SetStringAsync(cacheKey, serialized, options, cancellationToken);
     }
 
-    private static string GetCacheKey(string url)
-    {
-        // Use SHA256 hash of URL to create a safe, consistent cache key
-        var urlBytes = Encoding.UTF8.GetBytes(url);
-        var hashBytes = SHA256.HashData(urlBytes);
-        var hashString = Convert.ToBase64String(hashBytes).Replace("+", "-").Replace("/", "_").TrimEnd('=');
-
-        return $"{CacheKeyPrefix}{hashString}";
-    }
+    private static string GetCacheKey(Guid abonnementId) => CircuitBreakerCacheKeys.ForSubscriber(abonnementId);
 }

--- a/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/Services/RedisCircuitBreakerSubscriberHealthTracker.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/CircuitBreaker/Services/RedisCircuitBreakerSubscriberHealthTracker.cs
@@ -37,7 +37,7 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
 
             if (type == RedisType.Hash)
             {
-                var cachedData = await cache.GetStringAsync(key!, CancellationToken.None);
+                var cachedData = await cache.GetStringAsync(key!, cancellationToken);
                 if (cachedData == null)
                 {
                     continue;
@@ -72,11 +72,12 @@ public class RedisCircuitBreakerSubscriberHealthTracker(
             var clearedCount = 0;
             foreach (var kvp in unhealthySubscribers)
             {
-                if (dictOnlyTheseRedisKeys.Count > 0 && !dictOnlyTheseRedisKeys.Contains(kvp.Key.ToString()))
+                var redisKey = kvp.Key.ToString();
+                if (dictOnlyTheseRedisKeys.Count > 0 && !dictOnlyTheseRedisKeys.Contains(redisKey))
                 {
                     continue;
                 }
-                await cache.RemoveAsync(kvp.Key!, cancellationToken);
+                await cache.RemoveAsync(redisKey, cancellationToken);
                 clearedCount++;
             }
 

--- a/src/OneGround.ZGW.Notificaties.Messaging/Configuration/HangfireConfiguration.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/Configuration/HangfireConfiguration.cs
@@ -18,6 +18,8 @@ internal class HangfireConfiguration
     public string ExpireFailedJobsScanAt { get; set; } = "05:00"; // UTC
     public TimeSpan ExpireFailedJobAfter { get; set; } = TimeSpan.FromDays(7);
 
+    public string BlockFailingSubscriptionsScanCron { get; set; } = "0 * * * *";
+
     private static void AssurValid(TimeSpan[] value)
     {
         // Note: Timespan serie sometimes difficult to understand. You can have 00:00:00:05 or 00:00:05 or 1.00:00:00 but the ordering is important for correct working

--- a/src/OneGround.ZGW.Notificaties.Messaging/Consumers/NotDeliveredException.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/Consumers/NotDeliveredException.cs
@@ -11,3 +11,9 @@ public class GeneralException : Exception
     public GeneralException(string message)
         : base(message) { }
 }
+
+public class SubscriptionBlockedException : Exception
+{
+    public SubscriptionBlockedException(string message)
+        : base(message) { }
+}

--- a/src/OneGround.ZGW.Notificaties.Messaging/Consumers/SendNotificatiesConsumer.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/Consumers/SendNotificatiesConsumer.cs
@@ -71,17 +71,6 @@ public class SendNotificatiesConsumer : ConsumerBase<SendNotificatiesConsumer>, 
 
                 foreach (var abonnement in abonnementen)
                 {
-                    if (abonnement.Blocked)
-                    {
-                        Logger.LogInformation(
-                            "{Consumer}: subscription {AbonnementId} is blocked; no delivery job enqueued for channel '{Kanaal}'.",
-                            nameof(SendNotificatiesConsumer),
-                            abonnement.Id,
-                            notificatie.Kanaal
-                        );
-                        continue;
-                    }
-
                     if (ShouldNotifySubscriber(notificatie, abonnement, out var resolvedKenmerkBronnen))
                     {
                         SendNotificatieToSubscriber(context, notificatie, abonnement, resolvedKenmerkBronnen);

--- a/src/OneGround.ZGW.Notificaties.Messaging/Consumers/SendNotificatiesConsumer.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/Consumers/SendNotificatiesConsumer.cs
@@ -207,7 +207,7 @@ public class SendNotificatiesConsumer : ConsumerBase<SendNotificatiesConsumer>, 
 
                 var _abonnementen = await dbContext
                     .Abonnementen.AsNoTracking()
-                    .Where(a => a.Owner == rsin)
+                    .Where(a => a.Owner == rsin && !a.Blocked)
                     .Include(a => a.AbonnementKanalen)
                         .ThenInclude(a => a.Kanaal)
                     .Include(a => a.AbonnementKanalen)

--- a/src/OneGround.ZGW.Notificaties.Messaging/Consumers/SendNotificatiesConsumer.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/Consumers/SendNotificatiesConsumer.cs
@@ -71,6 +71,17 @@ public class SendNotificatiesConsumer : ConsumerBase<SendNotificatiesConsumer>, 
 
                 foreach (var abonnement in abonnementen)
                 {
+                    if (abonnement.Blocked)
+                    {
+                        Logger.LogInformation(
+                            "{Consumer}: subscription {AbonnementId} is blocked; no delivery job enqueued for channel '{Kanaal}'.",
+                            nameof(SendNotificatiesConsumer),
+                            abonnement.Id,
+                            notificatie.Kanaal
+                        );
+                        continue;
+                    }
+
                     if (ShouldNotifySubscriber(notificatie, abonnement, out var resolvedKenmerkBronnen))
                     {
                         SendNotificatieToSubscriber(context, notificatie, abonnement, resolvedKenmerkBronnen);

--- a/src/OneGround.ZGW.Notificaties.Messaging/Jobs/Extensions/NotificatiesJobsServiceExtensions.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/Jobs/Extensions/NotificatiesJobsServiceExtensions.cs
@@ -17,5 +17,6 @@ public static class NotificatiesJobsServiceExtensions
     public static void AddNotificatiesServerJobs(this IServiceCollection services)
     {
         services.AddTransient<NotificatieJob>();
+        services.AddTransient<BlockFailingSubscriptionsJob>();
     }
 }

--- a/src/OneGround.ZGW.Notificaties.Messaging/Jobs/Notificatie/BlockFailingSubscriptionsJob.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/Jobs/Notificatie/BlockFailingSubscriptionsJob.cs
@@ -1,0 +1,142 @@
+using System.Globalization;
+using Hangfire;
+using Hangfire.Server;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using OneGround.ZGW.Notificaties.DataModel;
+using OneGround.ZGW.Notificaties.Messaging.CircuitBreaker;
+using OneGround.ZGW.Notificaties.Messaging.CircuitBreaker.Options;
+using OneGround.ZGW.Notificaties.Messaging.Jobs.Filters;
+using StackExchange.Redis;
+
+namespace OneGround.ZGW.Notificaties.Messaging.Jobs.Notificatie;
+
+public interface IBlockFailingSubscriptionsJob
+{
+    Task BlockFailingSubscriptionsAsync(PerformContext context = null);
+}
+
+[Queue(Constants.NrcListenerMainQueue)]
+[RetryQueue(Constants.NrcListenerRetryQueue)]
+public class BlockFailingSubscriptionsJob : IBlockFailingSubscriptionsJob
+{
+    private readonly IDistributedCache _cache;
+    private readonly IConnectionMultiplexer _connectionMultiplexer;
+    private readonly IOptions<CircuitBreakerOptions> _circuitBreakerOptions;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly ILogger<BlockFailingSubscriptionsJob> _logger;
+
+    public BlockFailingSubscriptionsJob(
+        IDistributedCache cache,
+        IConnectionMultiplexer connectionMultiplexer,
+        IOptions<CircuitBreakerOptions> circuitBreakerOptions,
+        IServiceScopeFactory serviceScopeFactory,
+        ILogger<BlockFailingSubscriptionsJob> logger
+    )
+    {
+        _cache = cache;
+        _connectionMultiplexer = connectionMultiplexer;
+        _circuitBreakerOptions = circuitBreakerOptions;
+        _serviceScopeFactory = serviceScopeFactory;
+        _logger = logger;
+    }
+
+    public async Task BlockFailingSubscriptionsAsync(PerformContext context = null)
+    {
+        try
+        {
+            var expired = await GetExpiredFailingSubscriptionsAsync(CancellationToken.None);
+            if (expired.Count == 0)
+            {
+                return;
+            }
+
+            var blocked = await BlockSubscriptionsAsync(expired, CancellationToken.None);
+
+            foreach (var abonnementId in expired)
+            {
+                await _cache.RemoveAsync(CircuitBreakerCacheKeys.ForFailingSince(abonnementId), CancellationToken.None);
+            }
+
+            _logger.LogWarning(
+                "Block-scan: blocked {BlockedCount} subscription(s) that were failing continuously for at least {BlockSubscriptionAfter}.",
+                blocked,
+                _circuitBreakerOptions.Value.BlockSubscriptionAfter
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Block-scan: failed to block expired failing subscriptions. Will retry on the next scheduled run.");
+        }
+    }
+
+    private async Task<IReadOnlyList<Guid>> GetExpiredFailingSubscriptionsAsync(CancellationToken cancellationToken)
+    {
+        var expired = new List<Guid>();
+
+        var endpoint = _connectionMultiplexer.GetEndPoints()[0];
+        IServer server = _connectionMultiplexer.GetServer(endpoint);
+
+        foreach (var key in server.Keys(pattern: $"{CircuitBreakerCacheKeys.FailingSincePrefix}*"))
+        {
+            if (key == default(RedisKey))
+            {
+                continue;
+            }
+
+            var keyString = key.ToString();
+            var suffix = keyString[CircuitBreakerCacheKeys.FailingSincePrefix.Length..];
+
+            if (!Guid.TryParse(suffix, out var abonnementId))
+            {
+                _logger.LogWarning("Skipping failing-since marker with unparseable subscription id in key '{Key}'.", keyString);
+                continue;
+            }
+
+            var value = await _cache.GetStringAsync(keyString, cancellationToken);
+            if (value == null || !DateTime.TryParse(value, null, DateTimeStyles.RoundtripKind, out var failingSince))
+            {
+                _logger.LogWarning("Skipping failing-since marker '{Key}' with unparseable timestamp value '{Value}'.", keyString, value);
+                continue;
+            }
+
+            if (DateTime.UtcNow - failingSince >= _circuitBreakerOptions.Value.BlockSubscriptionAfter)
+            {
+                expired.Add(abonnementId);
+            }
+        }
+
+        return expired;
+    }
+
+    /// <summary>
+    /// Marks the given subscriptions as blocked in the database. Uses a tracked load+save (NOT
+    /// ExecuteUpdateAsync) so it works against the in-memory provider used in tests. Returns the
+    /// number of subscriptions actually transitioned to blocked.
+    /// </summary>
+    // Public so the DB-block step can be unit-tested independently of the Redis keyspace enumeration.
+    public async Task<int> BlockSubscriptionsAsync(IReadOnlyCollection<Guid> ids, CancellationToken cancellationToken = default)
+    {
+        if (ids.Count == 0)
+        {
+            return 0;
+        }
+
+        using var scope = _serviceScopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<NrcDbContext>();
+
+        var abonnementen = await dbContext.Abonnementen.Where(a => ids.Contains(a.Id) && !a.Blocked).ToListAsync(cancellationToken);
+
+        foreach (var abonnement in abonnementen)
+        {
+            abonnement.Blocked = true;
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return abonnementen.Count;
+    }
+}

--- a/src/OneGround.ZGW.Notificaties.Messaging/Jobs/Notificatie/NotificatieJob.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/Jobs/Notificatie/NotificatieJob.cs
@@ -58,6 +58,21 @@ public class NotificatieJob : INotificatieJob
                 _logger.LogWarning("Abonnement with id {abonnementId} not found. Probably deleted within the retry period of the job.", abonnementId);
                 return; // Job Ignored->Succeeded
             }
+            if (subscriber.Blocked)
+            {
+                _logger.LogWarning(
+                    "Abonnement {AbonnementId} is blocked. Notification on channel '{Kanaal}' not delivered. Unblock the subscription to resume delivery.",
+                    abonnementId,
+                    notificatie.Kanaal
+                );
+                context.WriteLineColored(
+                    ConsoleTextColor.Red,
+                    $"Abonnement '{abonnementId}' is blocked. Notification on channel '{notificatie.Kanaal}' not delivered."
+                );
+                throw new SubscriptionBlockedException(
+                    $"{DateTime.Now:yyyy-MM-dd HH:mm:ss} {notificatie.CorrelationId}: Abonnement '{abonnementId}' is blocked; notification on channel '{notificatie.Kanaal}' not delivered."
+                );
+            }
             if (string.IsNullOrWhiteSpace(subscriber.CallbackUrl))
             {
                 throw new GeneralException(
@@ -74,7 +89,7 @@ public class NotificatieJob : INotificatieJob
                 $"Try to deliver notification to subscriber '{subscriber.CallbackUrl}' on channel '{notificatie.Kanaal}'."
             );
 
-            var result = await _notificationSender.SendAsync(notificatie, subscriber.CallbackUrl, subscriber.Auth);
+            var result = await _notificationSender.SendAsync(notificatie, abonnementId, subscriber.CallbackUrl, subscriber.Auth);
             if (!result.Success)
             {
                 context.WriteLineColored(

--- a/src/OneGround.ZGW.Notificaties.Messaging/NotificationSender.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/NotificationSender.cs
@@ -14,7 +14,13 @@ namespace OneGround.ZGW.Notificaties.Messaging;
 
 public interface INotificationSender
 {
-    public Task<SubscriberResult> SendAsync(INotificatie notificatie, string url, string auth, CancellationToken cancellationToken = default);
+    public Task<SubscriberResult> SendAsync(
+        INotificatie notificatie,
+        Guid abonnementId,
+        string url,
+        string auth,
+        CancellationToken cancellationToken = default
+    );
 }
 
 public class NotificationSender : INotificationSender
@@ -43,12 +49,18 @@ public class NotificationSender : INotificationSender
         _healthTracker = healthTracker;
     }
 
-    public async Task<SubscriberResult> SendAsync(INotificatie notificatie, string url, string auth, CancellationToken cancellationToken = default)
+    public async Task<SubscriberResult> SendAsync(
+        INotificatie notificatie,
+        Guid abonnementId,
+        string url,
+        string auth,
+        CancellationToken cancellationToken = default
+    )
     {
         ArgumentNullException.ThrowIfNull(notificatie);
 
         // Circuit breaker: Check if subscriber is healthy before attempting to send
-        var isHealthy = await SafeHealthCheckAsync(url, cancellationToken);
+        var isHealthy = await SafeHealthCheckAsync(abonnementId, url, cancellationToken);
         if (!isHealthy)
         {
             _logger.LogWarning(
@@ -123,7 +135,7 @@ public class NotificationSender : INotificationSender
             if (response.IsSuccessStatusCode)
             {
                 // Circuit breaker: Mark subscriber as healthy on success
-                await _healthTracker.MarkHealthyAsync(url, cancellationToken);
+                await _healthTracker.MarkHealthyAsync(abonnementId, cancellationToken);
 
                 _logger.LogDebug(
                     "{NotificationSender}: Subscriber marked as healthy. URL: {Url}, Channel: {Kanaal}",
@@ -137,7 +149,13 @@ public class NotificationSender : INotificationSender
             else
             {
                 // Circuit breaker: Mark subscriber as unhealthy on HTTP error
-                await _healthTracker.MarkUnhealthyAsync(url, $"HTTP {(int)response.StatusCode}", (int)response.StatusCode, cancellationToken);
+                await _healthTracker.MarkUnhealthyAsync(
+                    abonnementId,
+                    url,
+                    $"HTTP {(int)response.StatusCode}",
+                    (int)response.StatusCode,
+                    cancellationToken
+                );
 
                 _logger.LogWarning(
                     "{NotificationSender}: Subscriber marked as unhealthy due to HTTP error. URL: {Url}, Channel: {Kanaal}, Status: {StatusCode}",
@@ -158,12 +176,7 @@ public class NotificationSender : INotificationSender
         catch (TaskCanceledException tce)
         {
             // Circuit breaker: Mark subscriber as unhealthy on timeout
-            await _healthTracker.MarkUnhealthyAsync(
-                url,
-                "Request timeout",
-                statusCode: 408, // Request Timeout
-                cancellationToken
-            );
+            await _healthTracker.MarkUnhealthyAsync(abonnementId, url, "Request timeout", statusCode: 408, cancellationToken);
 
             // Note: Don't log the complete error stacktrace here (client consumer)
             _logger.LogWarning(
@@ -179,7 +192,7 @@ public class NotificationSender : INotificationSender
         catch (HttpRequestException httpEx)
         {
             // Circuit breaker: Mark subscriber as unhealthy on connection error
-            await _healthTracker.MarkUnhealthyAsync(url, httpEx.Message, statusCode: (int?)httpEx.StatusCode, cancellationToken);
+            await _healthTracker.MarkUnhealthyAsync(abonnementId, url, httpEx.Message, statusCode: (int?)httpEx.StatusCode, cancellationToken);
 
             _logger.LogWarning(
                 httpEx,
@@ -200,7 +213,7 @@ public class NotificationSender : INotificationSender
         catch (Exception ex)
         {
             // Circuit breaker: Mark subscriber as unhealthy on unexpected error
-            await _healthTracker.MarkUnhealthyAsync(url, "Unexpected error", statusCode: null, cancellationToken);
+            await _healthTracker.MarkUnhealthyAsync(abonnementId, url, "Unexpected error", statusCode: null, cancellationToken);
 
             // Note: Don't log the complete error stacktrace here (client consumer)
             _logger.LogWarning(
@@ -219,11 +232,11 @@ public class NotificationSender : INotificationSender
     /// Safely checks subscriber health with fail-open behavior.
     /// If health tracker fails, allows notification through.
     /// </summary>
-    private async Task<bool> SafeHealthCheckAsync(string url, CancellationToken cancellationToken)
+    private async Task<bool> SafeHealthCheckAsync(Guid abonnementId, string url, CancellationToken cancellationToken)
     {
         try
         {
-            return await _healthTracker.IsHealthyAsync(url, cancellationToken);
+            return await _healthTracker.IsHealthyAsync(abonnementId, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/OneGround.ZGW.Notificaties.Messaging/ServiceConfiguration.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/ServiceConfiguration.cs
@@ -200,6 +200,19 @@ public class ServiceConfiguration
                     RecurringJob.RemoveIfExists("expire-failed-jobs");
                 }
 
+                if (IsBlockFailingSubscriptionsScannerEnabled)
+                {
+                    RecurringJob.AddOrUpdate<BlockFailingSubscriptionsJob>(
+                        "block-failing-subscriptions",
+                        j => j.BlockFailingSubscriptionsAsync(null),
+                        _hangfireConfiguration.BlockFailingSubscriptionsScanCron
+                    );
+                }
+                else
+                {
+                    RecurringJob.RemoveIfExists("block-failing-subscriptions");
+                }
+
                 o.UseConsole();
             }
         );
@@ -226,6 +239,10 @@ public class ServiceConfiguration
     private bool IsExpireFailedJobsScannerEnabled =>
         !string.IsNullOrWhiteSpace(_hangfireConfiguration.ExpireFailedJobsScanAt)
         && !DisabledValues.Contains(_hangfireConfiguration.ExpireFailedJobsScanAt.Trim());
+
+    private bool IsBlockFailingSubscriptionsScannerEnabled =>
+        !string.IsNullOrWhiteSpace(_hangfireConfiguration.BlockFailingSubscriptionsScanCron)
+        && !DisabledValues.Contains(_hangfireConfiguration.BlockFailingSubscriptionsScanCron.Trim());
 
     private static readonly HashSet<string> DisabledValues = new(StringComparer.OrdinalIgnoreCase) { "never", "disabled", "n/a" };
 

--- a/src/OneGround.ZGW.Notificaties.Messaging/UI/UnhealthMonitorDashboardPage.cs
+++ b/src/OneGround.ZGW.Notificaties.Messaging/UI/UnhealthMonitorDashboardPage.cs
@@ -40,6 +40,7 @@ public class UnhealthMonitorDashboardPage : IDashboardDispatcher
             tableRows.AppendLine(
                 $@"
                 <tr class='{statusClass}'>
+                    <td>{state.AbonnementId}</td>
                     <td>{encodedUrl}</td>
                     <td class='status-badge'>{statusText}</td>
                     <td>{state.ConsecutiveFailures}</td>
@@ -566,6 +567,7 @@ public class UnhealthMonitorDashboardPage : IDashboardDispatcher
                         <table>
                             <thead>
                                 <tr>
+                                    <th>Abonnement Id</th>
                                     <th>Subscriber URL</th>
                                     <th>Status</th>
                                     <th>Failures</th>

--- a/src/OneGround.ZGW.Notificaties.Web/Handlers/DeleteAbonnementCommandHandler.cs
+++ b/src/OneGround.ZGW.Notificaties.Web/Handlers/DeleteAbonnementCommandHandler.cs
@@ -36,7 +36,10 @@ class DeleteAbonnementCommandHandler : ZGWBaseHandler, IRequestHandler<DeleteAbo
 
         var rsinFilter = GetRsinFilterPredicate<Abonnement>();
 
-        var abonnement = await _context.Abonnementen.Where(rsinFilter).Where(a => !a.Blocked).SingleOrDefaultAsync(a => a.Id == request.Id, cancellationToken);
+        var abonnement = await _context
+            .Abonnementen.Where(rsinFilter)
+            .Where(a => !a.Blocked)
+            .SingleOrDefaultAsync(a => a.Id == request.Id, cancellationToken);
 
         if (abonnement == null)
         {

--- a/src/OneGround.ZGW.Notificaties.Web/Handlers/DeleteAbonnementCommandHandler.cs
+++ b/src/OneGround.ZGW.Notificaties.Web/Handlers/DeleteAbonnementCommandHandler.cs
@@ -36,7 +36,7 @@ class DeleteAbonnementCommandHandler : ZGWBaseHandler, IRequestHandler<DeleteAbo
 
         var rsinFilter = GetRsinFilterPredicate<Abonnement>();
 
-        var abonnement = await _context.Abonnementen.Where(rsinFilter).SingleOrDefaultAsync(a => a.Id == request.Id, cancellationToken);
+        var abonnement = await _context.Abonnementen.Where(rsinFilter).Where(a => !a.Blocked).SingleOrDefaultAsync(a => a.Id == request.Id, cancellationToken);
 
         if (abonnement == null)
         {

--- a/src/OneGround.ZGW.Notificaties.Web/Handlers/GetAbonnementQueryHandler.cs
+++ b/src/OneGround.ZGW.Notificaties.Web/Handlers/GetAbonnementQueryHandler.cs
@@ -43,7 +43,7 @@ class GetAbonnementQueryHandler : ZGWBaseHandler, IRequestHandler<GetAbonnementQ
                 .ThenInclude(a => a.Kanaal)
             .Include(a => a.AbonnementKanalen)
                 .ThenInclude(a => a.Filters)
-            .SingleOrDefaultAsync(a => a.Id == request.Id, cancellationToken);
+            .SingleOrDefaultAsync(a => a.Id == request.Id && !a.Blocked, cancellationToken);
 
         if (abonnement == null)
         {

--- a/src/OneGround.ZGW.Notificaties.Web/Handlers/GetAbonnementQueryHandler.cs
+++ b/src/OneGround.ZGW.Notificaties.Web/Handlers/GetAbonnementQueryHandler.cs
@@ -16,13 +16,13 @@ namespace OneGround.ZGW.Notificaties.Web.Handlers;
 class GetAbonnementQueryHandler : ZGWBaseHandler, IRequestHandler<GetAbonnementQuery, QueryResult<Abonnement>>
 {
     private readonly NrcDbContext _context;
-    private readonly ILogger<GetAllAbonnementenQueryHandler> _logger;
+    private readonly ILogger<GetAbonnementQueryHandler> _logger;
 
     public GetAbonnementQueryHandler(
         IConfiguration configuration,
         IAuthorizationContextAccessor authorizationContextAccessor,
         NrcDbContext context,
-        ILogger<GetAllAbonnementenQueryHandler> logger
+        ILogger<GetAbonnementQueryHandler> logger
     )
         : base(configuration, authorizationContextAccessor)
     {

--- a/src/OneGround.ZGW.Notificaties.Web/Handlers/GetAbonnementQueryHandler.cs
+++ b/src/OneGround.ZGW.Notificaties.Web/Handlers/GetAbonnementQueryHandler.cs
@@ -39,11 +39,12 @@ class GetAbonnementQueryHandler : ZGWBaseHandler, IRequestHandler<GetAbonnementQ
         var abonnement = await _context
             .Abonnementen.AsNoTracking()
             .Where(rsinFilter)
+            .Where(a => !a.Blocked)
             .Include(a => a.AbonnementKanalen)
                 .ThenInclude(a => a.Kanaal)
             .Include(a => a.AbonnementKanalen)
                 .ThenInclude(a => a.Filters)
-            .SingleOrDefaultAsync(a => a.Id == request.Id && !a.Blocked, cancellationToken);
+            .SingleOrDefaultAsync(a => a.Id == request.Id, cancellationToken);
 
         if (abonnement == null)
         {

--- a/src/OneGround.ZGW.Notificaties.Web/Handlers/GetAllAbonnementenQueryHandler.cs
+++ b/src/OneGround.ZGW.Notificaties.Web/Handlers/GetAllAbonnementenQueryHandler.cs
@@ -39,6 +39,7 @@ class GetAllAbonnementenQueryHandler : ZGWBaseHandler, IRequestHandler<GetAllAbo
         var result = await _context
             .Abonnementen.AsNoTracking()
             .Where(rsinFilter)
+            .Where(a => !a.Blocked)
             .Include(a => a.AbonnementKanalen)
                 .ThenInclude(a => a.Kanaal)
             .Include(a => a.AbonnementKanalen)

--- a/src/OneGround.ZGW.Notificaties.Web/Handlers/UpdateAbonnementCommandHandler.cs
+++ b/src/OneGround.ZGW.Notificaties.Web/Handlers/UpdateAbonnementCommandHandler.cs
@@ -44,6 +44,7 @@ class UpdateAbonnementCommandHandler : ZGWBaseHandler, IRequestHandler<UpdateAbo
 
         var abonnement = await _context
             .Abonnementen.Where(rsinFilter)
+            .Where(a => !a.Blocked)
             .Include(a => a.AbonnementKanalen)
             .SingleOrDefaultAsync(a => a.Id == request.Id, cancellationToken);
 

--- a/src/OneGround.ZGW.Notificaties.Web/MappingProfiles/v1/RequestToDomainProfile.cs
+++ b/src/OneGround.ZGW.Notificaties.Web/MappingProfiles/v1/RequestToDomainProfile.cs
@@ -14,6 +14,7 @@ public class RequestToDomainProfile : Profile
         CreateMap<AbonnementRequestDto, Abonnement>()
             .ForMember(dest => dest.Id, opt => opt.Ignore())
             .ForMember(dest => dest.AbonnementKanalen, opt => opt.MapFrom(src => src.Kanalen))
+            .ForMember(dest => dest.Blocked, opt => opt.Ignore())
             .ForMember(dest => dest.Owner, opt => opt.Ignore());
 
         CreateMap<AbonnementKanaalDto, AbonnementKanaal>()

--- a/src/Tests/OneGround.ZGW.Notificaties.Messaging.Listener.UnitTests/CircuitBreaker/RedisCircuitBreakerSubscriberHealthTrackerTests.cs
+++ b/src/Tests/OneGround.ZGW.Notificaties.Messaging.Listener.UnitTests/CircuitBreaker/RedisCircuitBreakerSubscriberHealthTrackerTests.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Globalization;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using AutoFixture;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -21,7 +22,16 @@ public class RedisCircuitBreakerSubscriberHealthTrackerTests
     private readonly Mock<ILogger<RedisCircuitBreakerSubscriberHealthTracker>> _loggerMock;
     private readonly CircuitBreakerOptions _settings;
     private readonly RedisCircuitBreakerSubscriberHealthTracker _sut;
-    private readonly Fixture _fixture;
+
+    private static readonly Guid AbonnementId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+    private const string Url = "https://example.com/webhook";
+    private static readonly string BreakerKey = $"ZGW:NRC:CircuitBreaker:subscriber:{AbonnementId}";
+    private static readonly string MarkerKey = $"ZGW:NRC:CircuitBreaker:failing-since:{AbonnementId}";
+
+    private CircuitBreakerSubscriberHealthState? _savedState;
+    private DistributedCacheEntryOptions? _savedStateOptions;
+    private string? _savedMarker;
+    private DistributedCacheEntryOptions? _savedMarkerOptions;
 
     public RedisCircuitBreakerSubscriberHealthTrackerTests()
     {
@@ -32,209 +42,253 @@ public class RedisCircuitBreakerSubscriberHealthTrackerTests
             FailureThreshold = 3,
             BreakDuration = TimeSpan.FromMinutes(5),
             CacheExpirationMinutes = 10,
+            BlockSubscriptionAfter = TimeSpan.FromDays(14),
         };
         var optionsMock = new Mock<IOptions<CircuitBreakerOptions>>();
         optionsMock.Setup(o => o.Value).Returns(_settings);
 
-        _sut = new RedisCircuitBreakerSubscriberHealthTracker(_cacheMock.Object, _loggerMock.Object, optionsMock.Object, new ConfigurationOptions());
-        _fixture = new Fixture();
+        // Capture every breaker-state write
+        _cacheMock
+            .Setup(c => c.SetAsync(BreakerKey, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<string, byte[], DistributedCacheEntryOptions, CancellationToken>(
+                (key, value, options, ct) =>
+                {
+                    _savedState = JsonSerializer.Deserialize<CircuitBreakerSubscriberHealthState>(Encoding.UTF8.GetString(value));
+                    _savedStateOptions = options;
+                }
+            )
+            .Returns(Task.CompletedTask);
+
+        // Capture every failing-since marker write
+        _cacheMock
+            .Setup(c => c.SetAsync(MarkerKey, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<string, byte[], DistributedCacheEntryOptions, CancellationToken>(
+                (key, value, options, ct) =>
+                {
+                    _savedMarker = Encoding.UTF8.GetString(value);
+                    _savedMarkerOptions = options;
+                }
+            )
+            .Returns(Task.CompletedTask);
+
+        _sut = new RedisCircuitBreakerSubscriberHealthTracker(
+            _cacheMock.Object,
+            _loggerMock.Object,
+            optionsMock.Object,
+            Mock.Of<IConnectionMultiplexer>()
+        );
     }
+
+    private void SetupState(CircuitBreakerSubscriberHealthState? state)
+    {
+        var bytes = state == null ? null : Encoding.UTF8.GetBytes(JsonSerializer.Serialize(state));
+        _cacheMock.Setup(c => c.GetAsync(BreakerKey, It.IsAny<CancellationToken>())).ReturnsAsync(bytes);
+    }
+
+    // ---------- IsHealthyAsync ----------
 
     [Fact]
     public async Task IsHealthyAsync_WhenNoHealthStateExists_ReturnsTrue()
     {
-        // Arrange
-        var url = "https://example.com/webhook";
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((byte[]?)null);
+        SetupState(null);
 
-        // Act
-        var result = await _sut.IsHealthyAsync(url);
+        var result = await _sut.IsHealthyAsync(AbonnementId);
 
-        // Assert
         Assert.True(result);
     }
 
     [Fact]
     public async Task IsHealthyAsync_WhenCircuitIsClosed_ReturnsTrue()
     {
-        // Arrange
-        var url = "https://example.com/webhook";
-        var healthState = new CircuitBreakerSubscriberHealthState
-        {
-            Url = url,
-            ConsecutiveFailures = 1,
-            BlockedUntil = null,
-        };
-        var serialized = JsonSerializer.Serialize(healthState);
-        var bytes = System.Text.Encoding.UTF8.GetBytes(serialized);
+        SetupState(
+            new CircuitBreakerSubscriberHealthState
+            {
+                AbonnementId = AbonnementId,
+                Url = Url,
+                ConsecutiveFailures = 1,
+                BlockedUntil = null,
+            }
+        );
 
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(bytes);
+        var result = await _sut.IsHealthyAsync(AbonnementId);
 
-        // Act
-        var result = await _sut.IsHealthyAsync(url);
-
-        // Assert
         Assert.True(result);
     }
 
     [Fact]
     public async Task IsHealthyAsync_WhenCircuitIsOpen_ReturnsFalse()
     {
-        // Arrange
-        var url = "https://example.com/webhook";
-        var healthState = new CircuitBreakerSubscriberHealthState
-        {
-            Url = url,
-            ConsecutiveFailures = 3,
-            BlockedUntil = DateTime.UtcNow.AddMinutes(5),
-        };
-        var serialized = JsonSerializer.Serialize(healthState);
-        var bytes = System.Text.Encoding.UTF8.GetBytes(serialized);
+        SetupState(
+            new CircuitBreakerSubscriberHealthState
+            {
+                AbonnementId = AbonnementId,
+                Url = Url,
+                ConsecutiveFailures = 3,
+                BlockedUntil = DateTime.UtcNow.AddMinutes(5),
+            }
+        );
 
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(bytes);
+        var result = await _sut.IsHealthyAsync(AbonnementId);
 
-        // Act
-        var result = await _sut.IsHealthyAsync(url);
-
-        // Assert
         Assert.False(result);
     }
 
     [Fact]
-    public async Task IsHealthyAsync_WhenCircuitExpired_ReturnsTrue()
+    public async Task IsHealthyAsync_UsesAbonnementIdBasedCacheKey()
     {
-        // Arrange
-        var url = "https://example.com/webhook";
-        var healthState = new CircuitBreakerSubscriberHealthState
-        {
-            Url = url,
-            ConsecutiveFailures = 3,
-            BlockedUntil = DateTime.UtcNow.AddMinutes(-1), // Already expired
-        };
-        var serialized = JsonSerializer.Serialize(healthState);
-        var bytes = System.Text.Encoding.UTF8.GetBytes(serialized);
+        SetupState(null);
 
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(bytes);
+        await _sut.IsHealthyAsync(AbonnementId);
 
-        // Act
-        var result = await _sut.IsHealthyAsync(url);
-
-        // Assert
-        Assert.True(result);
+        _cacheMock.Verify(c => c.GetAsync(BreakerKey, It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    [Fact]
+    public async Task IsHealthyAsync_WhenBlockedUntilExpires_TransitionsToHalfOpen_DeletingState()
+    {
+        SetupState(
+            new CircuitBreakerSubscriberHealthState
+            {
+                AbonnementId = AbonnementId,
+                Url = Url,
+                ConsecutiveFailures = 3,
+                BlockedUntil = DateTime.UtcNow.AddSeconds(-1), // expired -> half-open
+                FirstFailureAt = DateTime.UtcNow.AddMinutes(-10),
+                LastFailureAt = DateTime.UtcNow.AddMinutes(-5),
+            }
+        );
+
+        var result = await _sut.IsHealthyAsync(AbonnementId);
+
+        Assert.True(result); // one attempt allowed
+        // The short-lived breaker state is DELETED on half-open and no new state is written.
+        _cacheMock.Verify(c => c.RemoveAsync(BreakerKey, It.IsAny<CancellationToken>()), Times.Once);
+        _cacheMock.Verify(
+            c => c.SetAsync(BreakerKey, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task IsHealthyAsync_WhenCacheThrowsException_ReturnsTrue()
+    {
+        _cacheMock.Setup(c => c.GetAsync(BreakerKey, It.IsAny<CancellationToken>())).ThrowsAsync(new Exception("Redis connection failed"));
+
+        var result = await _sut.IsHealthyAsync(AbonnementId);
+
+        Assert.True(result); // fail-open
+    }
+
+    // ---------- MarkUnhealthyAsync: breaker cycle ----------
 
     [Fact]
     public async Task MarkUnhealthyAsync_FirstFailure_IncrementsFailureCount()
     {
-        // Arrange
-        var url = "https://example.com/webhook";
-        var errorMessage = "Connection timeout";
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((byte[]?)null);
+        SetupState(null);
 
-        CircuitBreakerSubscriberHealthState? savedState = null;
-        _cacheMock
-            .Setup(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()))
-            .Callback<string, byte[], DistributedCacheEntryOptions, CancellationToken>(
-                (key, value, options, ct) =>
-                    savedState = JsonSerializer.Deserialize<CircuitBreakerSubscriberHealthState>(System.Text.Encoding.UTF8.GetString(value))
-            )
-            .Returns(Task.CompletedTask);
+        await _sut.MarkUnhealthyAsync(AbonnementId, Url, "Connection timeout", 500);
 
-        // Act
-        await _sut.MarkUnhealthyAsync(url, errorMessage, 500);
-
-        // Assert
-        Assert.NotNull(savedState);
-        Assert.Equal(url, savedState.Url);
-        Assert.Equal(1, savedState.ConsecutiveFailures);
-        Assert.Equal(errorMessage, savedState.LastErrorMessage);
-        Assert.Equal(500, savedState.LastStatusCode);
-        Assert.NotNull(savedState.FirstFailureAt);
-        Assert.NotNull(savedState.LastFailureAt);
-        Assert.Null(savedState.BlockedUntil); // Circuit not open yet
+        Assert.NotNull(_savedState);
+        Assert.Equal(AbonnementId, _savedState.AbonnementId);
+        Assert.Equal(Url, _savedState.Url);
+        Assert.Equal(1, _savedState.ConsecutiveFailures);
+        Assert.Equal("Connection timeout", _savedState.LastErrorMessage);
+        Assert.Equal(500, _savedState.LastStatusCode);
+        Assert.Null(_savedState.BlockedUntil);
     }
 
     [Fact]
     public async Task MarkUnhealthyAsync_ReachesThreshold_OpensCircuit()
     {
-        // Arrange
-        var url = "https://example.com/webhook";
-        var existingState = new CircuitBreakerSubscriberHealthState
-        {
-            Url = url,
-            ConsecutiveFailures = 2, // One below threshold
-            FirstFailureAt = DateTime.UtcNow.AddMinutes(-2),
-        };
-        var serialized = JsonSerializer.Serialize(existingState);
-        var bytes = System.Text.Encoding.UTF8.GetBytes(serialized);
+        SetupState(
+            new CircuitBreakerSubscriberHealthState
+            {
+                AbonnementId = AbonnementId,
+                Url = Url,
+                ConsecutiveFailures = 2,
+                FirstFailureAt = DateTime.UtcNow.AddMinutes(-2),
+                LastFailureAt = DateTime.UtcNow.AddMinutes(-1),
+            }
+        );
 
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(bytes);
+        await _sut.MarkUnhealthyAsync(AbonnementId, Url, "Third failure");
 
-        CircuitBreakerSubscriberHealthState? savedState = null;
-        _cacheMock
-            .Setup(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()))
-            .Callback<string, byte[], DistributedCacheEntryOptions, CancellationToken>(
-                (key, value, options, ct) =>
-                    savedState = JsonSerializer.Deserialize<CircuitBreakerSubscriberHealthState>(System.Text.Encoding.UTF8.GetString(value))
-            )
-            .Returns(Task.CompletedTask);
-
-        // Act
-        await _sut.MarkUnhealthyAsync(url, "Third failure");
-
-        // Assert
-        Assert.NotNull(savedState);
-        Assert.Equal(3, savedState.ConsecutiveFailures);
-        Assert.NotNull(savedState.BlockedUntil);
-        Assert.True(savedState.BlockedUntil > DateTime.UtcNow);
-        Assert.True(savedState.IsCircuitOpen);
+        Assert.NotNull(_savedState);
+        Assert.Equal(3, _savedState.ConsecutiveFailures);
+        Assert.NotNull(_savedState.BlockedUntil);
+        Assert.True(_savedState.IsCircuitOpen);
     }
 
     [Fact]
-    public async Task MarkHealthyAsync_ResetsHealthState()
+    public async Task MarkUnhealthyAsync_SavesStateWithTenMinuteTtl()
     {
-        // Arrange
-        var url = "https://example.com/webhook";
-        var healthState = new CircuitBreakerSubscriberHealthState
-        {
-            Url = url,
-            ConsecutiveFailures = 2,
-            BlockedUntil = DateTime.UtcNow.AddMinutes(5),
-        };
-        var serialized = JsonSerializer.Serialize(healthState);
-        var bytes = System.Text.Encoding.UTF8.GetBytes(serialized);
+        SetupState(null);
 
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(bytes);
+        await _sut.MarkUnhealthyAsync(AbonnementId, Url, "boom", 500);
 
-        // Act
-        await _sut.MarkHealthyAsync(url);
-
-        // Assert
-        _cacheMock.Verify(c => c.RemoveAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.NotNull(_savedStateOptions);
+        Assert.Equal(TimeSpan.FromMinutes(_settings.CacheExpirationMinutes), _savedStateOptions.AbsoluteExpirationRelativeToNow);
     }
+
+    // ---------- MarkHealthyAsync ----------
+
+    [Fact]
+    public async Task MarkHealthyAsync_ResetsState()
+    {
+        SetupState(
+            new CircuitBreakerSubscriberHealthState
+            {
+                AbonnementId = AbonnementId,
+                Url = Url,
+                ConsecutiveFailures = 2,
+                BlockedUntil = DateTime.UtcNow.AddMinutes(5),
+            }
+        );
+
+        await _sut.MarkHealthyAsync(AbonnementId);
+
+        _cacheMock.Verify(c => c.RemoveAsync(BreakerKey, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task MarkHealthyAsync_WhenNoBreakerState_DoesNotTouchBreakerKey()
+    {
+        SetupState(null);
+
+        await _sut.MarkHealthyAsync(AbonnementId);
+
+        _cacheMock.Verify(c => c.RemoveAsync(BreakerKey, It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task MarkHealthyAsync_WhenNoBreakerState_ClearsFailingSinceMarker()
+    {
+        SetupState(null);
+
+        await _sut.MarkHealthyAsync(AbonnementId);
+
+        _cacheMock.Verify(c => c.RemoveAsync(MarkerKey, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ---------- Get/Reset ----------
 
     [Fact]
     public async Task GetHealthStateAsync_WhenStateExists_ReturnsState()
     {
-        // Arrange
-        var url = "https://example.com/webhook";
-        var healthState = new CircuitBreakerSubscriberHealthState
-        {
-            Url = url,
-            ConsecutiveFailures = 2,
-            LastErrorMessage = "Test error",
-        };
-        var serialized = JsonSerializer.Serialize(healthState);
-        var bytes = System.Text.Encoding.UTF8.GetBytes(serialized);
+        SetupState(
+            new CircuitBreakerSubscriberHealthState
+            {
+                AbonnementId = AbonnementId,
+                Url = Url,
+                ConsecutiveFailures = 2,
+                LastErrorMessage = "Test error",
+            }
+        );
 
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(bytes);
+        var result = await _sut.GetHealthStateAsync(AbonnementId);
 
-        // Act
-        var result = await _sut.GetHealthStateAsync(url);
-
-        // Assert
         Assert.NotNull(result);
-        Assert.Equal(url, result.Url);
+        Assert.Equal(AbonnementId, result.AbonnementId);
         Assert.Equal(2, result.ConsecutiveFailures);
         Assert.Equal("Test error", result.LastErrorMessage);
     }
@@ -242,255 +296,101 @@ public class RedisCircuitBreakerSubscriberHealthTrackerTests
     [Fact]
     public async Task GetHealthStateAsync_WhenNoStateExists_ReturnsNull()
     {
-        // Arrange
-        var url = "https://example.com/webhook";
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((byte[]?)null);
+        SetupState(null);
 
-        // Act
-        var result = await _sut.GetHealthStateAsync(url);
+        var result = await _sut.GetHealthStateAsync(AbonnementId);
 
-        // Assert
         Assert.Null(result);
     }
 
     [Fact]
-    public async Task ResetHealthAsync_RemovesCacheEntry()
+    public async Task ResetHealthAsync_RemovesTheStateKey()
     {
-        // Arrange
-        var url = "https://example.com/webhook";
+        await _sut.ResetHealthAsync(AbonnementId);
 
-        // Act
-        await _sut.ResetHealthAsync(url);
-
-        // Assert
-        _cacheMock.Verify(c => c.RemoveAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        _cacheMock.Verify(c => c.RemoveAsync(BreakerKey, It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    [Fact]
-    public async Task IsHealthyAsync_WhenCacheThrowsException_ReturnsTrue()
-    {
-        // Arrange
-        var url = "https://example.com/webhook";
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ThrowsAsync(new Exception("Redis connection failed"));
-
-        // Act
-        var result = await _sut.IsHealthyAsync(url);
-
-        // Assert
-        Assert.True(result); // Fail-open behavior
-    }
+    // ---------- Half-open failure flow ----------
 
     [Fact]
-    public async Task HalfOpenState_WhenBlockedUntilExpires_TransitionsToHalfOpen_AndReturnsHealthy()
+    public async Task HalfOpenState_WhenFailureAfterExpiry_ReopensCircuitAfterThreshold()
     {
-        // Arrange - Circuit is OPEN with BlockedUntil in the past
-        var url = "https://example.com/webhook";
-        var healthState = new CircuitBreakerSubscriberHealthState
-        {
-            Url = url,
-            ConsecutiveFailures = 3,
-            BlockedUntil = DateTime.UtcNow.AddSeconds(-1), // Expired 1 second ago
-            FirstFailureAt = DateTime.UtcNow.AddMinutes(-10),
-            LastFailureAt = DateTime.UtcNow.AddMinutes(-5),
-        };
-        var serialized = JsonSerializer.Serialize(healthState);
-        var bytes = System.Text.Encoding.UTF8.GetBytes(serialized);
+        // After half-open deleted the state, failures start a fresh breaker cycle.
+        _cacheMock.Setup(c => c.GetAsync(BreakerKey, It.IsAny<CancellationToken>())).ReturnsAsync((byte[]?)null);
 
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(bytes);
-
-        // Setup to capture the MarkHealthyAsync call (which clears the state)
-        _cacheMock.Setup(c => c.RemoveAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-
-        // Act
-        var result = await _sut.IsHealthyAsync(url);
-
-        // Assert
-        Assert.True(result); // Should return true, allowing one attempt
-        _cacheMock.Verify(c => c.RemoveAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once); // State should be cleared
-    }
-
-    [Fact]
-    public async Task HalfOpenState_WhenSuccessfulAfterExpiry_TransitionsToClosed()
-    {
-        // Arrange - Simulate the full flow:
-        // 1. Circuit was OPEN with expired BlockedUntil
-        // 2. IsHealthyAsync transitions to HALF-OPEN (clears state)
-        // 3. Request succeeds and calls MarkHealthyAsync
-        var url = "https://example.com/webhook";
-
-        // Step 1: Circuit is open but BlockedUntil has expired
-        var openState = new CircuitBreakerSubscriberHealthState
-        {
-            Url = url,
-            ConsecutiveFailures = 3,
-            BlockedUntil = DateTime.UtcNow.AddSeconds(-1),
-            FirstFailureAt = DateTime.UtcNow.AddMinutes(-10),
-            LastFailureAt = DateTime.UtcNow.AddMinutes(-5),
-        };
-        var serializedOpen = JsonSerializer.Serialize(openState);
-        var bytesOpen = System.Text.Encoding.UTF8.GetBytes(serializedOpen);
-
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(bytesOpen);
-        _cacheMock.Setup(c => c.RemoveAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-
-        // Step 2: Check health - should transition to HALF-OPEN
-        var isHealthy = await _sut.IsHealthyAsync(url);
-        Assert.True(isHealthy);
-
-        // Step 3: After successful request, state should already be cleared
-        // Verify the state was cleared (transitioned to CLOSED)
-        _cacheMock.Verify(c => c.RemoveAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
-    }
-
-    [Fact]
-    public async Task HalfOpenState_WhenFailureAfterExpiry_ReopensCircuit()
-    {
-        // Arrange - Simulate the flow where a failure occurs during HALF-OPEN state
-        var url = "https://example.com/webhook";
-
-        CircuitBreakerSubscriberHealthState? savedState = null;
-
-        // Setup mock to capture state and also return it on next GetAsync call
+        // Each SetAsync updates what the next GetAsync returns (simulates the real cache)
         _cacheMock
-            .Setup(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()))
+            .Setup(c => c.SetAsync(BreakerKey, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()))
             .Callback<string, byte[], DistributedCacheEntryOptions, CancellationToken>(
                 (key, value, options, ct) =>
                 {
-                    savedState = JsonSerializer.Deserialize<CircuitBreakerSubscriberHealthState>(System.Text.Encoding.UTF8.GetString(value));
-                    // Update the GetAsync mock to return the latest state
-                    _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(value);
+                    _savedState = JsonSerializer.Deserialize<CircuitBreakerSubscriberHealthState>(Encoding.UTF8.GetString(value));
+                    _cacheMock.Setup(c => c.GetAsync(BreakerKey, It.IsAny<CancellationToken>())).ReturnsAsync(value);
                 }
             )
             .Returns(Task.CompletedTask);
 
-        // Step 1: Circuit was OPEN, BlockedUntil expired, and IsHealthyAsync cleared the state (HALF-OPEN)
-        // Now there's no state (or minimal state)
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((byte[]?)null);
+        await _sut.MarkUnhealthyAsync(AbonnementId, Url, "Failed during half-open", 500);
+        Assert.Equal(1, _savedState!.ConsecutiveFailures);
+        Assert.Null(_savedState.BlockedUntil);
 
-        // Step 2: First failure in monitoring state
-        await _sut.MarkUnhealthyAsync(url, "Failed during half-open", 500);
+        await _sut.MarkUnhealthyAsync(AbonnementId, Url, "Failed again", 500);
+        Assert.Equal(2, _savedState!.ConsecutiveFailures);
+        Assert.Null(_savedState.BlockedUntil);
 
-        // Assert - Should have 1 failure but circuit still monitoring
-        Assert.NotNull(savedState);
-        Assert.Equal(1, savedState.ConsecutiveFailures);
-        Assert.Null(savedState.BlockedUntil); // Not blocked yet
+        await _sut.MarkUnhealthyAsync(AbonnementId, Url, "Failed third time", 500);
+        Assert.Equal(3, _savedState!.ConsecutiveFailures);
+        Assert.NotNull(_savedState.BlockedUntil);
+        Assert.True(_savedState.IsCircuitOpen);
+    }
 
-        // Step 3: Continue marking as unhealthy until threshold is reached
-        await _sut.MarkUnhealthyAsync(url, "Failed again during half-open", 500);
+    // ---------- EnsureFailingSinceAsync ----------
 
-        // After second failure, should have 2 consecutive failures
-        Assert.NotNull(savedState);
-        Assert.Equal(2, savedState.ConsecutiveFailures);
-        Assert.Null(savedState.BlockedUntil); // Still not blocked yet
-
-        await _sut.MarkUnhealthyAsync(url, "Failed third time during half-open", 500);
-
-        // Assert - Circuit should RE-OPEN after reaching threshold during HALF-OPEN
-        Assert.NotNull(savedState);
-        Assert.Equal(3, savedState.ConsecutiveFailures);
-        Assert.NotNull(savedState.BlockedUntil);
-        Assert.True(savedState.BlockedUntil > DateTime.UtcNow);
-        Assert.True(savedState.IsCircuitOpen);
+    private void SetupMarker(DateTime? failingSinceUtc)
+    {
+        var bytes = failingSinceUtc == null ? null : Encoding.UTF8.GetBytes(failingSinceUtc.Value.ToString("O"));
+        _cacheMock.Setup(c => c.GetAsync(MarkerKey, It.IsAny<CancellationToken>())).ReturnsAsync(bytes);
     }
 
     [Fact]
-    public async Task HalfOpenState_DetectsMonitoringState_AndLogsAppropriately()
+    public async Task EnsureFailingSinceAsync_WhenMarkerAbsent_WritesMarkerWithUtcNowAndLongTtl()
     {
-        // Arrange - Simulate a state that indicates HALF-OPEN monitoring
-        // (BlockedUntil is null, but there's a recent failure)
-        var url = "https://example.com/webhook";
-        var halfOpenState = new CircuitBreakerSubscriberHealthState
-        {
-            Url = url,
-            ConsecutiveFailures = 1, // Below threshold
-            BlockedUntil = null, // Not blocked
-            FirstFailureAt = DateTime.UtcNow.AddSeconds(-10),
-            LastFailureAt = DateTime.UtcNow.AddSeconds(-5), // Recent failure
-        };
-        var serialized = JsonSerializer.Serialize(halfOpenState);
-        var bytes = System.Text.Encoding.UTF8.GetBytes(serialized);
+        SetupMarker(null);
 
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(bytes);
+        await _sut.EnsureFailingSinceAsync(AbonnementId);
 
-        CircuitBreakerSubscriberHealthState? savedState = null;
-        _cacheMock
-            .Setup(c => c.SetAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()))
-            .Callback<string, byte[], DistributedCacheEntryOptions, CancellationToken>(
-                (key, value, options, ct) =>
-                    savedState = JsonSerializer.Deserialize<CircuitBreakerSubscriberHealthState>(System.Text.Encoding.UTF8.GetString(value))
-            )
-            .Returns(Task.CompletedTask);
+        _cacheMock.Verify(
+            c => c.SetAsync(MarkerKey, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once
+        );
 
-        // Act - Mark as unhealthy while in monitoring state
-        await _sut.MarkUnhealthyAsync(url, "Failed during monitoring", 500);
+        Assert.NotNull(_savedMarker);
+        var failingSince = DateTime.Parse(_savedMarker, null, DateTimeStyles.RoundtripKind);
+        Assert.True((DateTime.UtcNow - failingSince).Duration() < TimeSpan.FromMinutes(1));
+        Assert.Equal(_settings.FailingSinceMarkerExpiration, _savedMarkerOptions!.AbsoluteExpirationRelativeToNow);
+    }
 
-        // Assert - Should increment failures
-        Assert.NotNull(savedState);
-        Assert.Equal(2, savedState.ConsecutiveFailures);
+    [Fact]
+    public async Task EnsureFailingSinceAsync_WhenMarkerAlreadyExists_DoesNotRewriteIt()
+    {
+        SetupMarker(DateTime.UtcNow.AddDays(-2));
 
-        // Verify that appropriate logging occurred (optional - depends on your logging requirements)
-        _loggerMock.Verify(
-            x =>
-                x.Log(
-                    LogLevel.Information,
-                    It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("marked as unhealthy")),
-                    It.IsAny<Exception>(),
-                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
-                ),
-            Times.AtLeastOnce
+        await _sut.EnsureFailingSinceAsync(AbonnementId);
+
+        _cacheMock.Verify(
+            c => c.SetAsync(MarkerKey, It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()),
+            Times.Never
         );
     }
 
+    // ---------- ClearFailingSinceAsync ----------
+
     [Fact]
-    public async Task HalfOpenState_CompleteFlow_OpenToHalfOpenToClosedOnSuccess()
+    public async Task ClearFailingSinceAsync_RemovesMarkerKey()
     {
-        // This test simulates the complete happy path:
-        // OPEN → HALF-OPEN (on expiry) → CLOSED (on success)
+        await _sut.ClearFailingSinceAsync(AbonnementId);
 
-        var url = "https://example.com/webhook";
-
-        // Step 1: Circuit is OPEN (BlockedUntil in the future)
-        var openState = new CircuitBreakerSubscriberHealthState
-        {
-            Url = url,
-            ConsecutiveFailures = 3,
-            BlockedUntil = DateTime.UtcNow.AddSeconds(10), // Still blocked
-            FirstFailureAt = DateTime.UtcNow.AddMinutes(-10),
-            LastFailureAt = DateTime.UtcNow.AddMinutes(-5),
-        };
-        var serializedOpen = JsonSerializer.Serialize(openState);
-        _cacheMock
-            .Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(System.Text.Encoding.UTF8.GetBytes(serializedOpen));
-
-        var isHealthyWhileOpen = await _sut.IsHealthyAsync(url);
-        Assert.False(isHealthyWhileOpen); // Should be unhealthy (OPEN)
-
-        // Step 2: Time passes, BlockedUntil expires
-        var expiredState = new CircuitBreakerSubscriberHealthState
-        {
-            Url = url,
-            ConsecutiveFailures = 3,
-            BlockedUntil = DateTime.UtcNow.AddSeconds(-1), // Now expired
-            FirstFailureAt = DateTime.UtcNow.AddMinutes(-10),
-            LastFailureAt = DateTime.UtcNow.AddMinutes(-5),
-        };
-        var serializedExpired = JsonSerializer.Serialize(expiredState);
-        _cacheMock
-            .Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(System.Text.Encoding.UTF8.GetBytes(serializedExpired));
-        _cacheMock.Setup(c => c.RemoveAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
-
-        var isHealthyAfterExpiry = await _sut.IsHealthyAsync(url);
-        Assert.True(isHealthyAfterExpiry); // Should transition to HALF-OPEN and return true
-
-        // Step 3: Request succeeds - state should already be cleared (CLOSED)
-        _cacheMock.Verify(c => c.RemoveAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
-
-        // Step 4: Verify circuit is now CLOSED (no state)
-        _cacheMock.Setup(c => c.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((byte[]?)null);
-        var isHealthyAfterSuccess = await _sut.IsHealthyAsync(url);
-        Assert.True(isHealthyAfterSuccess); // Circuit is CLOSED
+        _cacheMock.Verify(c => c.RemoveAsync(MarkerKey, It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/src/Tests/OneGround.ZGW.Notificaties.Messaging.Listener.UnitTests/Jobs/BlockFailingSubscriptionsJobTests.cs
+++ b/src/Tests/OneGround.ZGW.Notificaties.Messaging.Listener.UnitTests/Jobs/BlockFailingSubscriptionsJobTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using OneGround.ZGW.Notificaties.DataModel;
+using OneGround.ZGW.Notificaties.Messaging.CircuitBreaker.Options;
+using OneGround.ZGW.Notificaties.Messaging.Jobs.Notificatie;
+using StackExchange.Redis;
+using Xunit;
+
+namespace OneGround.ZGW.Notificaties.Listener.UnitTests.Jobs;
+
+public class BlockFailingSubscriptionsJobTests
+{
+    private readonly Mock<IDistributedCache> _cacheMock = new();
+    private readonly Mock<IServiceScopeFactory> _serviceScopeFactoryMock = new();
+    private readonly CircuitBreakerOptions _settings = new()
+    {
+        FailureThreshold = 3,
+        BreakDuration = TimeSpan.FromMinutes(5),
+        CacheExpirationMinutes = 10,
+        BlockSubscriptionAfter = TimeSpan.FromDays(14),
+    };
+
+    private BlockFailingSubscriptionsJob CreateSut(IConnectionMultiplexer connectionMultiplexer)
+    {
+        var optionsMock = new Mock<IOptions<CircuitBreakerOptions>>();
+        optionsMock.Setup(o => o.Value).Returns(_settings);
+
+        return new BlockFailingSubscriptionsJob(
+            _cacheMock.Object,
+            connectionMultiplexer,
+            optionsMock.Object,
+            _serviceScopeFactoryMock.Object,
+            Mock.Of<ILogger<BlockFailingSubscriptionsJob>>()
+        );
+    }
+
+    [Fact]
+    public async Task BlockSubscriptionsAsync_BlocksOnlyUnblockedMatchingSubscriptions()
+    {
+        var unblockedMatching = Guid.NewGuid();
+        var alreadyBlocked = Guid.NewGuid();
+        var nonMatching = Guid.NewGuid();
+
+        var databaseName = $"nrc-{Guid.NewGuid()}";
+
+        await using (var seedContext = NewContext(databaseName))
+        {
+            seedContext.Database.EnsureCreated();
+            seedContext.Abonnementen.Add(NewAbonnement(unblockedMatching, blocked: false));
+            seedContext.Abonnementen.Add(NewAbonnement(alreadyBlocked, blocked: true));
+            seedContext.Abonnementen.Add(NewAbonnement(nonMatching, blocked: false));
+            await seedContext.SaveChangesAsync();
+        }
+
+        var serviceProvider = BuildServiceProvider(databaseName);
+        _serviceScopeFactoryMock.Setup(f => f.CreateScope()).Returns(() => serviceProvider.CreateScope());
+
+        var sut = CreateSut(Mock.Of<IConnectionMultiplexer>());
+
+        var blockedCount = await sut.BlockSubscriptionsAsync(new[] { unblockedMatching, alreadyBlocked });
+
+        Assert.Equal(1, blockedCount);
+
+        await using var readContext = NewContext(databaseName);
+        var reloaded = await readContext.Abonnementen.AsNoTracking().ToListAsync();
+        Assert.True(reloaded.Single(a => a.Id == unblockedMatching).Blocked);
+        Assert.True(reloaded.Single(a => a.Id == alreadyBlocked).Blocked);
+        Assert.False(reloaded.Single(a => a.Id == nonMatching).Blocked);
+    }
+
+    [Fact]
+    public async Task BlockFailingSubscriptionsAsync_WhenRedisUnavailable_DoesNotRethrow()
+    {
+        var redisMock = new Mock<IConnectionMultiplexer>();
+        redisMock
+            .Setup(r => r.GetEndPoints(It.IsAny<bool>()))
+            .Throws(new RedisConnectionException(ConnectionFailureType.UnableToConnect, "simulated unavailable"));
+
+        var sut = CreateSut(redisMock.Object);
+
+        var exception = await Record.ExceptionAsync(() => sut.BlockFailingSubscriptionsAsync(context: null));
+
+        Assert.Null(exception);
+    }
+
+    private static Abonnement NewAbonnement(Guid id, bool blocked) =>
+        new()
+        {
+            Id = id,
+            Blocked = blocked,
+            CallbackUrl = "https://example.com/webhook",
+            Auth = "Bearer token",
+            Owner = "00000000000",
+        };
+
+    private static NrcDbContext NewContext(string databaseName)
+    {
+        var options = new DbContextOptionsBuilder<NrcDbContext>().UseInMemoryDatabase(databaseName).Options;
+        return new NrcDbContext(options);
+    }
+
+    private static ServiceProvider BuildServiceProvider(string databaseName)
+    {
+        var serviceCollection = new ServiceCollection();
+        serviceCollection.AddScoped(_ => NewContext(databaseName));
+        return serviceCollection.BuildServiceProvider();
+    }
+}

--- a/src/Tests/OneGround.ZGW.Notificaties.Messaging.Listener.UnitTests/Jobs/NotificatieJobTests.cs
+++ b/src/Tests/OneGround.ZGW.Notificaties.Messaging.Listener.UnitTests/Jobs/NotificatieJobTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using OneGround.ZGW.Common.Batching;
+using OneGround.ZGW.Common.CorrelationId;
+using OneGround.ZGW.Common.Messaging;
+using OneGround.ZGW.Notificaties.DataModel;
+using OneGround.ZGW.Notificaties.Messaging;
+using OneGround.ZGW.Notificaties.Messaging.Consumers;
+using OneGround.ZGW.Notificaties.Messaging.Jobs.Notificatie;
+using OneGround.ZGW.Notificaties.Messaging.Services;
+using Xunit;
+
+namespace OneGround.ZGW.Notificaties.Listener.UnitTests.Jobs;
+
+public class NotificatieJobTests
+{
+    private readonly Mock<INotificationSender> _notificationSenderMock = new();
+    private readonly Mock<IAbonnementService> _abonnementServiceMock = new();
+    private readonly NotificatieJob _sut;
+
+    private static readonly Guid AbonnementId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    public NotificatieJobTests()
+    {
+        _sut = new NotificatieJob(
+            _notificationSenderMock.Object,
+            Mock.Of<IBatchIdAccessor>(),
+            Mock.Of<ICorrelationContextAccessor>(),
+            Mock.Of<ILogger<NotificatieJob>>(),
+            _abonnementServiceMock.Object
+        );
+    }
+
+    private static SubscriberNotificatie CreateNotificatie() =>
+        new()
+        {
+            Rsin = "000000000",
+            CorrelationId = Guid.NewGuid(),
+            Kanaal = "zaken",
+        };
+
+    [Fact]
+    public async Task ReQueueNotificatieAsync_WhenAbonnementIsBlocked_ThrowsSubscriptionBlockedExceptionWithoutSending()
+    {
+        _abonnementServiceMock
+            .Setup(s => s.GetByIdAsync(AbonnementId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                new Abonnement
+                {
+                    Id = AbonnementId,
+                    CallbackUrl = "https://example.com/webhook",
+                    Auth = "Bearer token",
+                    Blocked = true,
+                }
+            );
+
+        await Assert.ThrowsAsync<SubscriptionBlockedException>(() => _sut.ReQueueNotificatieAsync(AbonnementId, CreateNotificatie(), context: null));
+
+        _notificationSenderMock.Verify(
+            s => s.SendAsync(It.IsAny<INotificatie>(), It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task ReQueueNotificatieAsync_WhenAbonnementIsNotBlocked_SendsWithAbonnementId()
+    {
+        _abonnementServiceMock
+            .Setup(s => s.GetByIdAsync(AbonnementId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(
+                new Abonnement
+                {
+                    Id = AbonnementId,
+                    CallbackUrl = "https://example.com/webhook",
+                    Auth = "Bearer token",
+                    Blocked = false,
+                }
+            );
+        _notificationSenderMock
+            .Setup(s =>
+                s.SendAsync(It.IsAny<INotificatie>(), AbonnementId, "https://example.com/webhook", "Bearer token", It.IsAny<CancellationToken>())
+            )
+            .ReturnsAsync(new SubscriberResult { Success = true });
+
+        await _sut.ReQueueNotificatieAsync(AbonnementId, CreateNotificatie(), context: null);
+
+        _notificationSenderMock.Verify(
+            s => s.SendAsync(It.IsAny<INotificatie>(), AbonnementId, "https://example.com/webhook", "Bearer token", It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+    }
+}

--- a/src/Tests/OneGround.ZGW.Notificaties.Messaging.Listener.UnitTests/NotificatieConsumerTests.cs
+++ b/src/Tests/OneGround.ZGW.Notificaties.Messaging.Listener.UnitTests/NotificatieConsumerTests.cs
@@ -55,6 +55,9 @@ public class SendNotificatiesConsumerTests
         _configuration = Options.Create(new ApplicationOptions() { AbonnementenCacheExpirationTime = TimeSpan.FromMinutes(2) });
 
         _memoryCache = new MockMemoryCache();
+
+        // Existing tests assume an active (non-blocked) subscription; pin it so the skip-when-blocked guard doesn't flip them.
+        _fixture.Customize<Abonnement>(c => c.With(a => a.Blocked, false));
     }
 
     [Fact]
@@ -1119,6 +1122,63 @@ public class SendNotificatiesConsumerTests
         await consumer.Consume(message.Object);
 
         _notificatieScheduler.Verify(m => m.Enqueue(It.IsAny<Expression<Func<NotificatieJob, Task>>>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SendNotification_WhenSubscriptionBlocked_DoesNotEnqueue()
+    {
+        var channel = _fixture.Create<Kanaal>();
+        channel.Naam = "zaken";
+        channel.Filters = [];
+        channel.AbonnementKanalen = [];
+
+        var subscription = _fixture.Create<Abonnement>();
+        subscription.AbonnementKanalen = [];
+        subscription.Owner = "owner";
+        subscription.Blocked = true; // blocked
+
+        var context = await SetupDbContext(c =>
+        {
+            c.Kanalen.Add(channel);
+            c.Abonnementen.Add(subscription);
+            c.AbonnementKanalen.Add(
+                new AbonnementKanaal
+                {
+                    Abonnement = subscription,
+                    Kanaal = channel,
+                    Id = Guid.NewGuid(),
+                    Filters = [],
+                }
+            );
+        });
+
+        var serviceProvider = BuildServiceCollection(context);
+
+        var consumer = new SendNotificatiesConsumer(
+            _logger.Object,
+            serviceProvider,
+            _memoryCache,
+            _notificatieScheduler.Object,
+            _configuration,
+            _notificationFilterService.Object
+        );
+
+        var notificatie = new Mock<ISendNotificaties>();
+        notificatie.Setup(s => s.Kanaal).Returns("zaken");
+        notificatie.Setup(s => s.Rsin).Returns("owner");
+        // Not ignored: without the blocked-skip this WOULD enqueue.
+        _notificationFilterService
+            .Setup(x => x.IsIgnored(It.IsAny<ISendNotificaties>(), It.IsAny<Abonnement>(), It.IsAny<AbonnementKanaal>()))
+            .Returns(false);
+
+        var message = new Mock<ConsumeContext<ISendNotificaties>>();
+        message.Setup(s => s.Message).Returns(notificatie.Object);
+        var headersMock = new Mock<Headers>();
+        message.Setup(s => s.Headers).Returns(headersMock.Object);
+
+        await consumer.Consume(message.Object);
+
+        _notificatieScheduler.Verify(m => m.Enqueue(It.IsAny<Expression<Func<NotificatieJob, Task>>>()), Times.Never);
     }
 
     private static ServiceProvider BuildServiceCollection(NrcDbContext context)

--- a/src/Tests/OneGround.ZGW.Notificaties.Messaging.Listener.UnitTests/Services/NotificationSenderTests.cs
+++ b/src/Tests/OneGround.ZGW.Notificaties.Messaging.Listener.UnitTests/Services/NotificationSenderTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using OneGround.ZGW.Common.Batching;
+using OneGround.ZGW.Common.CorrelationId;
+using OneGround.ZGW.Notificaties.Messaging;
+using OneGround.ZGW.Notificaties.Messaging.CircuitBreaker.Services;
+using OneGround.ZGW.Notificaties.Messaging.Configuration;
+using Xunit;
+
+namespace OneGround.ZGW.Notificaties.Listener.UnitTests.Services;
+
+public class NotificationSenderTests
+{
+    private readonly Mock<ICircuitBreakerSubscriberHealthTracker> _healthTrackerMock = new();
+    private readonly StubHttpMessageHandler _handler = new();
+
+    private static readonly Guid AbonnementId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+    private const string Url = "https://example.com/webhook";
+
+    public NotificationSenderTests()
+    {
+        _healthTrackerMock.Setup(t => t.IsHealthyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+    }
+
+    private NotificationSender CreateSut()
+    {
+        var applicationOptions = new Mock<IOptions<ApplicationOptions>>();
+        applicationOptions.Setup(o => o.Value).Returns(new ApplicationOptions { CallbackTimeout = TimeSpan.FromSeconds(30) });
+
+        return new NotificationSender(
+            Mock.Of<ILogger<NotificationSender>>(),
+            new HttpClient(_handler),
+            Mock.Of<IBatchIdAccessor>(),
+            Mock.Of<ICorrelationContextAccessor>(),
+            _healthTrackerMock.Object,
+            applicationOptions.Object
+        );
+    }
+
+    private static SubscriberNotificatie CreateNotificatie() =>
+        new()
+        {
+            Rsin = "000000000",
+            CorrelationId = Guid.NewGuid(),
+            Kanaal = "zaken",
+        };
+
+    [Fact]
+    public async Task SendAsync_WhenDeliverySucceeds_ClearsFailingMarkerOnce()
+    {
+        _handler.ResponseStatusCode = HttpStatusCode.OK;
+        var sut = CreateSut();
+
+        var result = await sut.SendAsync(CreateNotificatie(), AbonnementId, Url, "Bearer token");
+
+        Assert.True(result.Success);
+        _healthTrackerMock.Verify(t => t.MarkHealthyAsync(AbonnementId, It.IsAny<CancellationToken>()), Times.Once);
+        _healthTrackerMock.Verify(
+            t => t.MarkUnhealthyAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenDeliveryFails_MarksFailingOnce()
+    {
+        _handler.ResponseStatusCode = HttpStatusCode.InternalServerError;
+        var sut = CreateSut();
+
+        var result = await sut.SendAsync(CreateNotificatie(), AbonnementId, Url, "Bearer token");
+
+        Assert.False(result.Success);
+        _healthTrackerMock.Verify(
+            t => t.MarkUnhealthyAsync(AbonnementId, Url, It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()),
+            Times.Once
+        );
+        _healthTrackerMock.Verify(t => t.MarkHealthyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        public HttpStatusCode ResponseStatusCode { get; set; } = HttpStatusCode.OK;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(ResponseStatusCode) { Content = new StringContent("") });
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

A set-once failing-since:<id> Redis marker records when the failure window started. A new hourly Hangfire job (BlockFailingSubscriptionsJob) scans these markers and DB-blocks any subscription failing ≥ BlockSubscriptionAfter (7 days). DB-blocked subscriptions throw SubscriptionBlockedException in NotificatieJob — straight to Failed, no retries.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

## Testing

- [x] Tests pass
- [x] Manual testing completed

## Checklist

- [x] Self-review completed
- [ ] Documentation updated (if needed)
